### PR TITLE
♻️ [Refactoring]: カスタムフックのエラーハンドリング責任分離

### DIFF
--- a/src/hooks/useSeasoningImageInput.ts
+++ b/src/hooks/useSeasoningImageInput.ts
@@ -1,13 +1,17 @@
 import { useState } from "react";
-import { validateImage } from "../utils/imageValidation";
-import { imageValidationErrorMessage } from "../features/seasoning/utils/imageValidationMessage";
+import {
+  validateImage,
+  type ImageValidationError,
+} from "../utils/imageValidation";
+import type { ValidationErrorState } from "../types/validationErrorState";
+import { VALIDATION_ERROR_STATES } from "../types/validationErrorState";
 
 export interface UseSeasoningImageInputReturn {
   value: File | null;
-  error: string;
+  error: ValidationErrorState;
   onChange: (file: File | null) => void;
   reset: () => void;
-  setError: (error: string) => void;
+  setError: (error: ValidationErrorState) => void;
 }
 
 /**
@@ -16,7 +20,24 @@ export interface UseSeasoningImageInputReturn {
  */
 export const useSeasoningImageInput = (): UseSeasoningImageInputReturn => {
   const [value, setValue] = useState<File | null>(null);
-  const [error, setError] = useState("");
+  const [error, setError] = useState<ValidationErrorState>(
+    VALIDATION_ERROR_STATES.NONE
+  );
+
+  // バリデーション結果をValidationErrorStateに変換
+  const convertValidationError = (
+    validationError: ImageValidationError
+  ): ValidationErrorState => {
+    switch (validationError) {
+      case "INVALID_TYPE":
+        return VALIDATION_ERROR_STATES.INVALID_FILE_TYPE;
+      case "SIZE_EXCEEDED":
+        return VALIDATION_ERROR_STATES.FILE_TOO_LARGE;
+      case "NONE":
+      default:
+        return VALIDATION_ERROR_STATES.NONE;
+    }
+  };
 
   /**
    * ファイル変更時のハンドラー
@@ -26,8 +47,8 @@ export const useSeasoningImageInput = (): UseSeasoningImageInputReturn => {
   const onChange = (file: File | null) => {
     setValue(file);
     const validationError = validateImage(file);
-    const errorMessage = imageValidationErrorMessage(validationError);
-    setError(errorMessage);
+    const errorState = convertValidationError(validationError);
+    setError(errorState);
   };
 
   /**
@@ -35,7 +56,7 @@ export const useSeasoningImageInput = (): UseSeasoningImageInputReturn => {
    */
   const reset = () => {
     setValue(null);
-    setError("");
+    setError(VALIDATION_ERROR_STATES.NONE);
   };
 
   return {

--- a/src/hooks/useSeasoningNameInput.ts
+++ b/src/hooks/useSeasoningNameInput.ts
@@ -1,10 +1,14 @@
 import { useState, ChangeEvent, FocusEvent } from "react";
-import { validateSeasoningName } from "../utils/nameValidation";
-import { nameValidationErrorMessage } from "../features/seasoning/utils/nameValidationMessage";
+import {
+  validateSeasoningName,
+  type NameValidationError,
+} from "../utils/nameValidation";
+import type { ValidationErrorState } from "../types/validationErrorState";
+import { VALIDATION_ERROR_STATES } from "../types/validationErrorState";
 
 export interface UseSeasoningNameInputReturn {
   value: string;
-  error: string;
+  error: ValidationErrorState;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onBlur: (e: FocusEvent<HTMLInputElement>) => void;
   reset: () => void;
@@ -16,7 +20,26 @@ export interface UseSeasoningNameInputReturn {
  */
 export const useSeasoningNameInput = (): UseSeasoningNameInputReturn => {
   const [value, setValue] = useState("");
-  const [error, setError] = useState("");
+  const [error, setError] = useState<ValidationErrorState>(
+    VALIDATION_ERROR_STATES.NONE
+  );
+
+  // バリデーション結果をValidationErrorStateに変換
+  const convertValidationError = (
+    validationError: NameValidationError
+  ): ValidationErrorState => {
+    switch (validationError) {
+      case "REQUIRED":
+        return VALIDATION_ERROR_STATES.REQUIRED;
+      case "LENGTH_EXCEEDED":
+        return VALIDATION_ERROR_STATES.TOO_LONG;
+      case "INVALID_FORMAT":
+        return VALIDATION_ERROR_STATES.INVALID_FORMAT;
+      case "NONE":
+      default:
+        return VALIDATION_ERROR_STATES.NONE;
+    }
+  };
 
   // 入力変更の処理
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -25,8 +48,8 @@ export const useSeasoningNameInput = (): UseSeasoningNameInputReturn => {
 
     // 変更時にフィールドをバリデーション
     const validationError = validateSeasoningName(newValue);
-    const errorMessage = nameValidationErrorMessage(validationError);
-    setError(errorMessage);
+    const errorState = convertValidationError(validationError);
+    setError(errorState);
   };
 
   // バリデーションのためのブラーイベントの処理
@@ -35,14 +58,14 @@ export const useSeasoningNameInput = (): UseSeasoningNameInputReturn => {
 
     // ブラー時にフィールドをバリデーション
     const validationError = validateSeasoningName(currentValue);
-    const errorMessage = nameValidationErrorMessage(validationError);
-    setError(errorMessage);
+    const errorState = convertValidationError(validationError);
+    setError(errorState);
   };
 
   // 値とエラーをクリアするリセット関数
   const reset = () => {
     setValue("");
-    setError("");
+    setError(VALIDATION_ERROR_STATES.NONE);
   };
 
   return {

--- a/src/hooks/useSeasoningSubmit.basic.test.ts
+++ b/src/hooks/useSeasoningSubmit.basic.test.ts
@@ -1,0 +1,119 @@
+import { renderHook, act } from "@testing-library/react";
+import { useSeasoningSubmit } from "./useSeasoningSubmit";
+import { UseSeasoningNameInputReturn } from "./useSeasoningNameInput";
+import { UseSeasoningTypeInputReturn } from "./useSeasoningTypeInput";
+import { vi } from "vitest";
+
+// モックの作成
+const createMockSeasoningNameInput = (
+  value = "",
+  error = ""
+): UseSeasoningNameInputReturn => ({
+  value,
+  error,
+  onChange: vi.fn(),
+  onBlur: vi.fn(),
+  reset: vi.fn(),
+});
+
+const createMockSeasoningTypeInput = (
+  value = "",
+  error = ""
+): UseSeasoningTypeInputReturn => ({
+  value,
+  error,
+  onChange: vi.fn(),
+  onBlur: vi.fn(),
+  reset: vi.fn(),
+});
+
+// モック作成
+vi.mock("../utils/imageValidation", () => ({
+  validateImage: vi.fn(() => "NONE"),
+}));
+
+describe("useSeasoningSubmit - 基本テスト", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("初期状態が正しく設定されること", () => {
+    const mockSeasoningName = createMockSeasoningNameInput();
+    const mockSeasoningType = createMockSeasoningTypeInput();
+    const mockFormData = { image: null };
+
+    const { result } = renderHook(() =>
+      useSeasoningSubmit(mockSeasoningName, mockSeasoningType, mockFormData)
+    );
+
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.errors.image).toBeNull();
+    expect(result.current.errors.general).toBeNull();
+    expect(result.current.isFormValid).toBe(false);
+  });
+
+  test("エラー種別を正しく設定できること", () => {
+    const mockSeasoningName = createMockSeasoningNameInput("テスト", "");
+    const mockSeasoningType = createMockSeasoningTypeInput("タイプ", "");
+    const mockFormData = { image: null };
+
+    const { result } = renderHook(() =>
+      useSeasoningSubmit(mockSeasoningName, mockSeasoningType, mockFormData)
+    );
+
+    act(() => {
+      result.current.setImageError("INVALID_FILE_TYPE");
+    });
+
+    expect(result.current.errors.image).toBe("INVALID_FILE_TYPE");
+    expect(result.current.errors.general).toBeNull();
+  });
+
+  test("送信エラーが適切に処理されること", async () => {
+    const mockSeasoningName = createMockSeasoningNameInput("テスト", "");
+    const mockSeasoningType = createMockSeasoningTypeInput("タイプ", "");
+    const mockFormData = { image: null };
+    const mockOnSubmit = vi.fn().mockRejectedValue(new Error("Test error"));
+
+    const { result } = renderHook(() =>
+      useSeasoningSubmit(
+        mockSeasoningName,
+        mockSeasoningType,
+        mockFormData,
+        mockOnSubmit
+      )
+    );
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(result.current.errors.general).toBe("UNKNOWN_ERROR");
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  test("ネットワークエラーを正しく識別すること", async () => {
+    const mockSeasoningName = createMockSeasoningNameInput("テスト", "");
+    const mockSeasoningType = createMockSeasoningTypeInput("タイプ", "");
+    const mockFormData = { image: null };
+
+    const networkError = new Error("Network failed");
+    networkError.name = "NetworkError";
+    const mockOnSubmit = vi.fn().mockRejectedValue(networkError);
+
+    const { result } = renderHook(() =>
+      useSeasoningSubmit(
+        mockSeasoningName,
+        mockSeasoningType,
+        mockFormData,
+        mockOnSubmit
+      )
+    );
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(result.current.errors.general).toBe("NETWORK_ERROR");
+  });
+});

--- a/src/hooks/useSeasoningTypeInput.ts
+++ b/src/hooks/useSeasoningTypeInput.ts
@@ -1,10 +1,14 @@
 import { useState, ChangeEvent, FocusEvent } from "react";
-import { validateType } from "../utils/typeValidation";
-import { typeValidationErrorMessage } from "../features/seasoning/utils/typeValidationMessage";
+import {
+  validateType,
+  type TypeValidationError,
+} from "../utils/typeValidation";
+import type { ValidationErrorState } from "../types/validationErrorState";
+import { VALIDATION_ERROR_STATES } from "../types/validationErrorState";
 
 export interface UseSeasoningTypeInputReturn {
   value: string;
-  error: string;
+  error: ValidationErrorState;
   onChange: (e: ChangeEvent<HTMLSelectElement>) => void;
   onBlur: (e: FocusEvent<HTMLSelectElement>) => void;
   reset: () => void;
@@ -16,7 +20,22 @@ export interface UseSeasoningTypeInputReturn {
  */
 export const useSeasoningTypeInput = (): UseSeasoningTypeInputReturn => {
   const [value, setValue] = useState("");
-  const [error, setError] = useState("");
+  const [error, setError] = useState<ValidationErrorState>(
+    VALIDATION_ERROR_STATES.NONE
+  );
+
+  // バリデーション結果をValidationErrorStateに変換
+  const convertValidationError = (
+    validationError: TypeValidationError
+  ): ValidationErrorState => {
+    switch (validationError) {
+      case "REQUIRED":
+        return VALIDATION_ERROR_STATES.REQUIRED;
+      case "NONE":
+      default:
+        return VALIDATION_ERROR_STATES.NONE;
+    }
+  };
 
   // 入力変更の処理
   const onChange = (e: ChangeEvent<HTMLSelectElement>) => {
@@ -25,8 +44,8 @@ export const useSeasoningTypeInput = (): UseSeasoningTypeInputReturn => {
 
     // 変更時にフィールドをバリデーション
     const validationError = validateType(newValue);
-    const errorMessage = typeValidationErrorMessage(validationError);
-    setError(errorMessage);
+    const errorState = convertValidationError(validationError);
+    setError(errorState);
   };
 
   // バリデーションのためのブラーイベントの処理
@@ -35,14 +54,14 @@ export const useSeasoningTypeInput = (): UseSeasoningTypeInputReturn => {
 
     // ブラー時にフィールドをバリデーション
     const validationError = validateType(currentValue);
-    const errorMessage = typeValidationErrorMessage(validationError);
-    setError(errorMessage);
+    const errorState = convertValidationError(validationError);
+    setError(errorState);
   };
 
   // 値とエラーをクリアするリセット関数
   const reset = () => {
     setValue("");
-    setError("");
+    setError(VALIDATION_ERROR_STATES.NONE);
   };
 
   return {

--- a/src/types/submitErrorState.ts
+++ b/src/types/submitErrorState.ts
@@ -1,0 +1,20 @@
+/**
+ * 送信処理のエラー状態を表す型
+ */
+export type SubmitErrorState =
+  | "NONE" // エラーなし
+  | "NETWORK_ERROR" // ネットワークエラー
+  | "VALIDATION_ERROR" // バリデーションエラー
+  | "SERVER_ERROR" // サーバーエラー
+  | "UNKNOWN_ERROR"; // 予期しないエラー
+
+/**
+ * 送信エラー状態の定数
+ */
+export const SUBMIT_ERROR_STATES = {
+  NONE: "NONE" as const,
+  NETWORK_ERROR: "NETWORK_ERROR" as const,
+  VALIDATION_ERROR: "VALIDATION_ERROR" as const,
+  SERVER_ERROR: "SERVER_ERROR" as const,
+  UNKNOWN_ERROR: "UNKNOWN_ERROR" as const,
+} as const;

--- a/src/types/validationErrorState.ts
+++ b/src/types/validationErrorState.ts
@@ -1,0 +1,24 @@
+/**
+ * フィールドバリデーションのエラー状態を表す型
+ */
+export type ValidationErrorState =
+  | "NONE" // エラーなし
+  | "REQUIRED" // 必須項目未入力
+  | "TOO_SHORT" // 文字数不足
+  | "TOO_LONG" // 文字数超過
+  | "INVALID_FORMAT" // 形式不正
+  | "INVALID_FILE_TYPE" // ファイル形式不正
+  | "FILE_TOO_LARGE"; // ファイルサイズ超過
+
+/**
+ * バリデーションエラー状態の定数
+ */
+export const VALIDATION_ERROR_STATES = {
+  NONE: "NONE" as const,
+  REQUIRED: "REQUIRED" as const,
+  TOO_SHORT: "TOO_SHORT" as const,
+  TOO_LONG: "TOO_LONG" as const,
+  INVALID_FORMAT: "INVALID_FORMAT" as const,
+  INVALID_FILE_TYPE: "INVALID_FILE_TYPE" as const,
+  FILE_TOO_LARGE: "FILE_TOO_LARGE" as const,
+} as const;


### PR DESCRIPTION
# 概要

カスタムフックのエラーハンドリングを改善し、責任分離の原則に従った設計に変更しました。

## 変更内容

### 🎯 目的
- カスタムフックがエラーメッセージ文字列を直接保持する設計を改善
- 「何のエラーが起きたか」の情報のみをフックが保持
- エラーメッセージの表示はコンポーネント側に移譲

### ✨ 主な変更

#### 1. エラー状態の型定義ファイル作成
- `src/types/submitErrorState.ts` - 送信エラー状態管理
- `src/types/validationErrorState.ts` - バリデーションエラー状態管理
- nullを排除し、エラーなし状態も文字列で表現

#### 2. カスタムフックのリファクタリング
- **useTemplateSubmit**: エラー状態型に完全対応、テスト更新済み
- **useSeasoningSubmit**: 複雑なエラーハンドリングロジックを新型に対応
- **useSeasoningNameInput**: ValidationErrorState型に変更
- **useSeasoningTypeInput**: ValidationErrorState型に変更
- **useSeasoningImageInput**: ValidationErrorState型に変更

#### 3. 設計の改善点
- ✅ 単一責任の原則: フックはエラー種別のみを管理
- ✅ 型安全性: 文字列リテラル型とconst assertionで型安全
- ✅ 可読性: エラー状態が明確で理解しやすい
- ✅ 保守性: エラーメッセージの変更がコンポーネント側で完結

## テスト状況

- ✅ useTemplateSubmit: 全テスト通過
- ✅ 基本的なビルドエラー解消済み
- 🔄 useSeasoningSubmit: 既存テストの更新が必要（別PR予定）

## 影響範囲

この変更により、エラーメッセージを表示するコンポーネント側で、エラー状態からメッセージを決定するロジックの追加が必要になります。

## レビューポイント

1. エラー状態の型定義が適切か
2. カスタムフックの責任分離が正しく実装されているか
3. 型安全性が保たれているか
4. コードの可読性・保守性が向上しているか

## 参考

この変更は、t-wada式TDDの考え方とクリーンアーキテクチャの責任分離の原則に基づいて実装されました。