### PR TITLE
✨ [New Feature]: 調味料種類追加のカスタムフック useSeasoningTypeAdd を実装

### DIFF
--- a/src/features/seasoning/utils/seasoningTypeValidationMessage.test.ts
+++ b/src/features/seasoning/utils/seasoningTypeValidationMessage.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from "vitest";
+import {
+  getSeasoningTypeValidationMessage,
+  getSeasoningTypeSubmitMessage,
+} from "./seasoningTypeValidationMessage";
+import {
+  VALIDATION_ERROR_STATES,
+  type ValidationErrorState,
+} from "../../../types/validationErrorState";
+import { SUBMIT_ERROR_STATES } from "../../../types/submitErrorState";
+
+describe("getSeasoningTypeValidationMessage", () => {
+  test("REQUIREDエラーの場合、必須メッセージを返す", () => {
+    const result = getSeasoningTypeValidationMessage(
+      VALIDATION_ERROR_STATES.REQUIRED
+    );
+    expect(result).toBe("調味料の種類名は必須です");
+  });
+
+  test("TOO_LONGエラーの場合、文字数制限メッセージを返す", () => {
+    const result = getSeasoningTypeValidationMessage(
+      VALIDATION_ERROR_STATES.TOO_LONG
+    );
+    expect(result).toBe("調味料の種類名は50文字以内で入力してください");
+  });
+
+  test("NONEエラーの場合、空文字を返す", () => {
+    const result = getSeasoningTypeValidationMessage(
+      VALIDATION_ERROR_STATES.NONE
+    );
+    expect(result).toBe("");
+  });
+
+  test("未定義のエラーの場合、空文字を返す", () => {
+    // 不正な値をValidationErrorStateとして扱う
+    const invalidError = "INVALID_FORMAT" as unknown as ValidationErrorState;
+    const result = getSeasoningTypeValidationMessage(invalidError);
+    expect(result).toBe("");
+  });
+});
+
+describe("getSeasoningTypeSubmitMessage", () => {
+  test("NETWORK_ERRORの場合、ネットワークエラーメッセージを返す", () => {
+    const result = getSeasoningTypeSubmitMessage(
+      SUBMIT_ERROR_STATES.NETWORK_ERROR
+    );
+    expect(result).toBe(
+      "通信エラーが発生しました。しばらくしてから再度お試しください"
+    );
+  });
+
+  test("VALIDATION_ERRORの場合、バリデーションエラーメッセージを返す", () => {
+    const result = getSeasoningTypeSubmitMessage(
+      SUBMIT_ERROR_STATES.VALIDATION_ERROR
+    );
+    expect(result).toBe("入力内容を確認してください");
+  });
+
+  test("SERVER_ERRORの場合、サーバーエラーメッセージを返す", () => {
+    const result = getSeasoningTypeSubmitMessage(
+      SUBMIT_ERROR_STATES.SERVER_ERROR
+    );
+    expect(result).toBe(
+      "システムエラーが発生しました。管理者にお問い合わせください"
+    );
+  });
+
+  test("UNKNOWN_ERRORの場合、一般的なエラーメッセージを返す", () => {
+    const result = getSeasoningTypeSubmitMessage(
+      SUBMIT_ERROR_STATES.UNKNOWN_ERROR
+    );
+    expect(result).toBe("調味料の種類の追加に失敗しました");
+  });
+
+  test("NONEの場合、空文字を返す", () => {
+    const result = getSeasoningTypeSubmitMessage(SUBMIT_ERROR_STATES.NONE);
+    expect(result).toBe("");
+  });
+});

--- a/src/features/seasoning/utils/seasoningTypeValidationMessage.ts
+++ b/src/features/seasoning/utils/seasoningTypeValidationMessage.ts
@@ -1,0 +1,46 @@
+import type { ValidationErrorState } from "../../../types/validationErrorState";
+import type { SubmitErrorState } from "../../../types/submitErrorState";
+
+/**
+ * 調味料の種類追加時のバリデーションエラーメッセージを取得
+ *
+ * @param error - バリデーションエラー状態
+ * @returns エラーメッセージ文字列
+ */
+export const getSeasoningTypeValidationMessage = (
+  error: ValidationErrorState
+): string => {
+  switch (error) {
+    case "REQUIRED":
+      return "調味料の種類名は必須です";
+    case "TOO_LONG":
+      return "調味料の種類名は50文字以内で入力してください";
+    case "NONE":
+    default:
+      return "";
+  }
+};
+
+/**
+ * 調味料の種類追加時の送信エラーメッセージを取得
+ *
+ * @param error - 送信エラー状態
+ * @returns エラーメッセージ文字列
+ */
+export const getSeasoningTypeSubmitMessage = (
+  error: SubmitErrorState
+): string => {
+  switch (error) {
+    case "NETWORK_ERROR":
+      return "通信エラーが発生しました。しばらくしてから再度お試しください";
+    case "VALIDATION_ERROR":
+      return "入力内容を確認してください";
+    case "SERVER_ERROR":
+      return "システムエラーが発生しました。管理者にお問い合わせください";
+    case "UNKNOWN_ERROR":
+      return "調味料の種類の追加に失敗しました";
+    case "NONE":
+    default:
+      return "";
+  }
+};

--- a/src/hooks/useSeasoningTypeAdd.test.ts
+++ b/src/hooks/useSeasoningTypeAdd.test.ts
@@ -1,0 +1,254 @@
+import { renderHook, act } from "@testing-library/react";
+import { vi } from "vitest";
+import { useSeasoningTypeAdd } from "./useSeasoningTypeAdd";
+import { VALIDATION_ERROR_STATES } from "../types/validationErrorState";
+import { SUBMIT_ERROR_STATES } from "../types/submitErrorState";
+
+describe("useSeasoningTypeAdd", () => {
+  describe("初期状態", () => {
+    test("初期状態が正しく設定されること", () => {
+      const { result } = renderHook(() => useSeasoningTypeAdd());
+
+      expect(result.current.name).toBe("");
+      expect(result.current.error).toBe(VALIDATION_ERROR_STATES.NONE);
+      expect(result.current.submitError).toBe(SUBMIT_ERROR_STATES.NONE);
+      expect(result.current.isSubmitting).toBe(false);
+      expect(result.current.isFormValid).toBe(false);
+    });
+  });
+
+  describe("名前の入力処理", () => {
+    test("名前を正しく更新できること", () => {
+      const { result } = renderHook(() => useSeasoningTypeAdd());
+
+      act(() => {
+        result.current.onChange({
+          target: { value: "新しい調味料タイプ" },
+        } as React.ChangeEvent<HTMLInputElement>);
+      });
+
+      expect(result.current.name).toBe("新しい調味料タイプ");
+    });
+
+    test("有効な名前でフォームが有効になること", () => {
+      const { result } = renderHook(() => useSeasoningTypeAdd());
+
+      act(() => {
+        result.current.onChange({
+          target: { value: "新しい調味料タイプ" },
+        } as React.ChangeEvent<HTMLInputElement>);
+      });
+
+      expect(result.current.isFormValid).toBe(true);
+    });
+  });
+
+  describe("バリデーション", () => {
+    test("空の名前でバリデーションエラーが表示されること", () => {
+      const { result } = renderHook(() => useSeasoningTypeAdd());
+
+      act(() => {
+        result.current.onBlur({
+          target: { value: "" },
+        } as React.FocusEvent<HTMLInputElement>);
+      });
+
+      expect(result.current.error).toBe(VALIDATION_ERROR_STATES.REQUIRED);
+      expect(result.current.isFormValid).toBe(false);
+    });
+
+    test("50文字を超える名前でバリデーションエラーが表示されること", () => {
+      const { result } = renderHook(() => useSeasoningTypeAdd());
+      const longName = "あ".repeat(51);
+
+      act(() => {
+        result.current.onChange({
+          target: { value: longName },
+        } as React.ChangeEvent<HTMLInputElement>);
+      });
+
+      expect(result.current.error).toBe(VALIDATION_ERROR_STATES.TOO_LONG);
+      expect(result.current.isFormValid).toBe(false);
+    });
+
+    test("50文字ちょうどの名前でエラーが発生しないこと", () => {
+      const { result } = renderHook(() => useSeasoningTypeAdd());
+      const maxLengthName = "あ".repeat(50);
+
+      act(() => {
+        result.current.onChange({
+          target: { value: maxLengthName },
+        } as React.ChangeEvent<HTMLInputElement>);
+      });
+
+      expect(result.current.error).toBe(VALIDATION_ERROR_STATES.NONE);
+      expect(result.current.isFormValid).toBe(true);
+    });
+  });
+
+  describe("送信処理", () => {
+    test("有効なデータで送信が成功すること", async () => {
+      const mockOnSubmit = vi.fn().mockResolvedValue(undefined);
+      const mockOnSuccess = vi.fn();
+      const { result } = renderHook(() =>
+        useSeasoningTypeAdd(mockOnSubmit, mockOnSuccess)
+      );
+
+      act(() => {
+        result.current.onChange({
+          target: { value: "新しい調味料タイプ" },
+        } as React.ChangeEvent<HTMLInputElement>);
+      });
+
+      await act(async () => {
+        await result.current.submit();
+      });
+
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        name: "新しい調味料タイプ",
+      });
+      expect(mockOnSuccess).toHaveBeenCalled();
+      expect(result.current.name).toBe("");
+      expect(result.current.error).toBe(VALIDATION_ERROR_STATES.NONE);
+      expect(result.current.submitError).toBe(SUBMIT_ERROR_STATES.NONE);
+    });
+
+    test("送信中の状態が正しく管理されること", async () => {
+      let resolvePromise: () => void;
+      const mockOnSubmit = vi.fn().mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolvePromise = resolve;
+          })
+      );
+      const { result } = renderHook(() => useSeasoningTypeAdd(mockOnSubmit));
+
+      act(() => {
+        result.current.onChange({
+          target: { value: "新しい調味料タイプ" },
+        } as React.ChangeEvent<HTMLInputElement>);
+      });
+
+      // 送信を開始（非同期でpromiseを返す）
+      act(() => {
+        result.current.submit();
+      });
+
+      // 送信中であることを確認
+      expect(result.current.isSubmitting).toBe(true);
+
+      // promiseを解決
+      await act(async () => {
+        resolvePromise();
+        await new Promise((resolve) => setTimeout(resolve, 0)); // Promiseの解決を待つ
+      });
+
+      expect(result.current.isSubmitting).toBe(false);
+    });
+
+    test("送信エラーが適切に処理されること", async () => {
+      const mockOnSubmit = vi.fn().mockRejectedValue(new Error("送信エラー"));
+      const { result } = renderHook(() => useSeasoningTypeAdd(mockOnSubmit));
+
+      act(() => {
+        result.current.onChange({
+          target: { value: "新しい調味料タイプ" },
+        } as React.ChangeEvent<HTMLInputElement>);
+      });
+
+      await act(async () => {
+        await result.current.submit();
+      });
+
+      expect(result.current.submitError).toBe(
+        SUBMIT_ERROR_STATES.UNKNOWN_ERROR
+      );
+      expect(result.current.isSubmitting).toBe(false);
+    });
+
+    test("ネットワークエラーが適切に処理されること", async () => {
+      const networkError = new Error("Network Error");
+      networkError.name = "NetworkError";
+      const mockOnSubmit = vi.fn().mockRejectedValue(networkError);
+      const { result } = renderHook(() => useSeasoningTypeAdd(mockOnSubmit));
+
+      act(() => {
+        result.current.onChange({
+          target: { value: "新しい調味料タイプ" },
+        } as React.ChangeEvent<HTMLInputElement>);
+      });
+
+      await act(async () => {
+        await result.current.submit();
+      });
+
+      expect(result.current.submitError).toBe(
+        SUBMIT_ERROR_STATES.NETWORK_ERROR
+      );
+      expect(result.current.isSubmitting).toBe(false);
+    });
+
+    test("サーバーエラーが適切に処理されること", async () => {
+      const serverError = new Error("Server Error occurred");
+      const mockOnSubmit = vi.fn().mockRejectedValue(serverError);
+      const { result } = renderHook(() => useSeasoningTypeAdd(mockOnSubmit));
+
+      act(() => {
+        result.current.onChange({
+          target: { value: "新しい調味料タイプ" },
+        } as React.ChangeEvent<HTMLInputElement>);
+      });
+
+      await act(async () => {
+        await result.current.submit();
+      });
+
+      expect(result.current.submitError).toBe(SUBMIT_ERROR_STATES.SERVER_ERROR);
+      expect(result.current.isSubmitting).toBe(false);
+    });
+
+    test("バリデーションエラーがある場合は送信されないこと", async () => {
+      const mockOnSubmit = vi.fn();
+      const { result } = renderHook(() => useSeasoningTypeAdd(mockOnSubmit));
+
+      await act(async () => {
+        await result.current.submit();
+      });
+
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+      expect(result.current.error).toBe(VALIDATION_ERROR_STATES.REQUIRED);
+    });
+  });
+
+  describe("リセット処理", () => {
+    test("resetが呼ばれた時に状態がリセットされること", () => {
+      const { result } = renderHook(() => useSeasoningTypeAdd());
+
+      // 値を設定
+      act(() => {
+        result.current.onChange({
+          target: { value: "テスト" },
+        } as React.ChangeEvent<HTMLInputElement>);
+      });
+
+      expect(result.current.name).toBe("テスト");
+
+      // エラーも設定
+      act(() => {
+        result.current.onBlur({
+          target: { value: "" },
+        } as React.FocusEvent<HTMLInputElement>);
+      });
+
+      // リセット
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.name).toBe("");
+      expect(result.current.error).toBe(VALIDATION_ERROR_STATES.NONE);
+      expect(result.current.submitError).toBe(SUBMIT_ERROR_STATES.NONE);
+      expect(result.current.isFormValid).toBe(false);
+    });
+  });
+});

--- a/src/hooks/useSeasoningTypeAdd.ts
+++ b/src/hooks/useSeasoningTypeAdd.ts
@@ -1,0 +1,184 @@
+import { useState, useCallback, useMemo, ChangeEvent, FocusEvent } from "react";
+import {
+  validateSeasoningTypeName,
+  type SeasoningTypeNameValidationError,
+} from "../utils/seasoningTypeNameValidation";
+import type { SeasoningTypeFormData } from "../types/seasoningType";
+import type { ValidationErrorState } from "../types/validationErrorState";
+import { VALIDATION_ERROR_STATES } from "../types/validationErrorState";
+import type { SubmitErrorState } from "../types/submitErrorState";
+import { SUBMIT_ERROR_STATES } from "../types/submitErrorState";
+
+// エラーハンドリング用の定数
+const ERROR_NAMES = {
+  NETWORK: "NetworkError",
+  VALIDATION: "ValidationError",
+} as const;
+
+const ERROR_MESSAGES = {
+  SERVER: "Server Error",
+} as const;
+
+export interface UseSeasoningTypeAddReturn {
+  /** 調味料の種類名 */
+  name: string;
+  /** バリデーションエラー状態 */
+  error: ValidationErrorState;
+  /** 送信エラー状態 */
+  submitError: SubmitErrorState;
+  /** 送信中フラグ */
+  isSubmitting: boolean;
+  /** フォーム有効性フラグ */
+  isFormValid: boolean;
+  /** 入力変更ハンドラー */
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  /** フォーカスアウトハンドラー */
+  onBlur: (e: FocusEvent<HTMLInputElement>) => void;
+  /** 送信処理 */
+  submit: () => Promise<void>;
+  /** リセット処理 */
+  reset: () => void;
+}
+
+/**
+ * エラーオブジェクトから適切なSubmitErrorStateを決定する
+ */
+const determineSubmitErrorState = (error: unknown): SubmitErrorState => {
+  if (!(error instanceof Error)) {
+    return SUBMIT_ERROR_STATES.UNKNOWN_ERROR;
+  }
+
+  if (error.name === ERROR_NAMES.NETWORK) {
+    return SUBMIT_ERROR_STATES.NETWORK_ERROR;
+  }
+
+  if (error.name === ERROR_NAMES.VALIDATION) {
+    return SUBMIT_ERROR_STATES.VALIDATION_ERROR;
+  }
+
+  if (error.message?.includes(ERROR_MESSAGES.SERVER)) {
+    return SUBMIT_ERROR_STATES.SERVER_ERROR;
+  }
+
+  return SUBMIT_ERROR_STATES.UNKNOWN_ERROR;
+};
+const convertValidationErrorToState = (
+  error: SeasoningTypeNameValidationError
+): ValidationErrorState => {
+  switch (error) {
+    case "REQUIRED":
+      return VALIDATION_ERROR_STATES.REQUIRED;
+    case "LENGTH_EXCEEDED":
+      return VALIDATION_ERROR_STATES.TOO_LONG;
+    case "NONE":
+    default:
+      return VALIDATION_ERROR_STATES.NONE;
+  }
+};
+
+/**
+ * 調味料の種類追加を管理するカスタムフック
+ * バリデーション、送信処理、エラー処理を行う
+ * エラーメッセージの文字列はコンポーネント側が責務を持つ
+ *
+ * @param onSubmit - 送信時のコールバック関数
+ * @param onSuccess - 送信成功時のコールバック関数
+ * @returns フック戻り値
+ */
+export const useSeasoningTypeAdd = (
+  onSubmit?: (data: SeasoningTypeFormData) => Promise<void>,
+  onSuccess?: () => void
+): UseSeasoningTypeAddReturn => {
+  const [name, setName] = useState("");
+  const [error, setError] = useState<ValidationErrorState>(
+    VALIDATION_ERROR_STATES.NONE
+  );
+  const [submitError, setSubmitError] = useState<SubmitErrorState>(
+    SUBMIT_ERROR_STATES.NONE
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // フォーム有効性をメモ化して計算
+  const isFormValid = useMemo((): boolean => {
+    const trimmedName = name.trim();
+    const validationError = validateSeasoningTypeName(trimmedName);
+    return trimmedName !== "" && validationError === "NONE";
+  }, [name]);
+
+  // 入力変更ハンドラー
+  const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    setName(newValue);
+
+    // リアルタイムバリデーション（文字数制限のみ）
+    const validationError = validateSeasoningTypeName(newValue.trim());
+    if (validationError === "LENGTH_EXCEEDED") {
+      setError(convertValidationErrorToState(validationError));
+    } else {
+      setError(VALIDATION_ERROR_STATES.NONE);
+    }
+  }, []);
+
+  // フォーカスアウトハンドラー
+  const onBlur = useCallback((e: FocusEvent<HTMLInputElement>) => {
+    const currentValue = e.target.value.trim();
+    const validationError = validateSeasoningTypeName(currentValue);
+    setError(convertValidationErrorToState(validationError));
+  }, []);
+
+  // 送信処理
+  const submit = useCallback(async (): Promise<void> => {
+    // ガード節: onSubmitが未定義の場合は早期リターン
+    if (!onSubmit) {
+      return;
+    }
+
+    const trimmedName = name.trim();
+    const validationError = validateSeasoningTypeName(trimmedName);
+
+    // ガード節: バリデーションエラーがある場合は早期リターン
+    if (validationError !== "NONE") {
+      setError(convertValidationErrorToState(validationError));
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      setError(VALIDATION_ERROR_STATES.NONE);
+      setSubmitError(SUBMIT_ERROR_STATES.NONE);
+
+      await onSubmit({
+        name: trimmedName,
+      });
+
+      // 送信成功時にフォームをリセット
+      setName("");
+      setError(VALIDATION_ERROR_STATES.NONE);
+      setSubmitError(SUBMIT_ERROR_STATES.NONE);
+      onSuccess?.();
+    } catch (error) {
+      setSubmitError(determineSubmitErrorState(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [name, onSubmit, onSuccess]);
+
+  // リセット処理
+  const reset = useCallback(() => {
+    setName("");
+    setError(VALIDATION_ERROR_STATES.NONE);
+    setSubmitError(SUBMIT_ERROR_STATES.NONE);
+  }, []);
+
+  return {
+    name,
+    error,
+    submitError,
+    isSubmitting,
+    isFormValid: isFormValid,
+    onChange,
+    onBlur,
+    submit,
+    reset,
+  };
+};

--- a/src/types/seasoningType.ts
+++ b/src/types/seasoningType.ts
@@ -1,0 +1,21 @@
+/**
+ * 調味料の種類を表す型
+ */
+export interface SeasoningType {
+  /** 一意識別子 */
+  id: string;
+  /** 調味料の種類名 */
+  name: string;
+  /** 作成日時 */
+  createdAt?: Date;
+  /** 更新日時 */
+  updatedAt?: Date;
+}
+
+/**
+ * 調味料の種類追加時のフォームデータ
+ */
+export interface SeasoningTypeFormData {
+  /** 調味料の種類名 */
+  name: string;
+}

--- a/src/utils/seasoningTypeNameValidation.test.ts
+++ b/src/utils/seasoningTypeNameValidation.test.ts
@@ -1,0 +1,42 @@
+import { validateSeasoningTypeName } from "./seasoningTypeNameValidation";
+
+describe("validateSeasoningTypeName", () => {
+  test("空の文字列の場合、REQUIRED エラーを返す", () => {
+    const result = validateSeasoningTypeName("");
+    expect(result).toBe("REQUIRED");
+  });
+
+  test("空白のみの文字列の場合、REQUIRED エラーを返す", () => {
+    const result = validateSeasoningTypeName("   ");
+    expect(result).toBe("REQUIRED");
+  });
+
+  test("有効な調味料の種類名の場合、NONE を返す", () => {
+    const result = validateSeasoningTypeName("香辛料");
+    expect(result).toBe("NONE");
+  });
+
+  test("最大文字数を超えた場合、LENGTH_EXCEEDED エラーを返す", () => {
+    const longName = "あ".repeat(51); // 51文字
+    const result = validateSeasoningTypeName(longName);
+    expect(result).toBe("LENGTH_EXCEEDED");
+  });
+
+  test("最大文字数ちょうど（50文字）の場合、NONE を返す", () => {
+    const maxLengthName = "あ".repeat(50);
+    const result = validateSeasoningTypeName(maxLengthName);
+    expect(result).toBe("NONE");
+  });
+
+  test("前後の空白が除去されてバリデーションされること", () => {
+    const nameWithSpaces = "  香辛料  ";
+    const result = validateSeasoningTypeName(nameWithSpaces);
+    expect(result).toBe("NONE");
+  });
+
+  test("前後の空白を含めて50文字を超える場合でも、trim後が50文字以内ならNONEを返す", () => {
+    const nameWithSpaces = "  " + "あ".repeat(50) + "  "; // trim後50文字
+    const result = validateSeasoningTypeName(nameWithSpaces);
+    expect(result).toBe("NONE");
+  });
+});

--- a/src/utils/seasoningTypeNameValidation.ts
+++ b/src/utils/seasoningTypeNameValidation.ts
@@ -1,0 +1,32 @@
+/**
+ * 調味料の種類名の最大文字数
+ */
+const MAX_SEASONING_TYPE_NAME_LENGTH = 50;
+
+/**
+ * 調味料の種類名バリデーションエラーの種類
+ */
+export type SeasoningTypeNameValidationError =
+  | "REQUIRED"
+  | "LENGTH_EXCEEDED"
+  | "NONE";
+
+/**
+ * 調味料の種類名のバリデーション
+ *
+ * @param name - 検証する調味料の種類名
+ * @returns エラーの種類（エラーがない場合は"NONE"）
+ */
+export const validateSeasoningTypeName = (
+  name: string
+): SeasoningTypeNameValidationError => {
+  if (!name || name.trim() === "") {
+    return "REQUIRED";
+  }
+
+  if (name.trim().length > MAX_SEASONING_TYPE_NAME_LENGTH) {
+    return "LENGTH_EXCEEDED";
+  }
+
+  return "NONE";
+};


### PR DESCRIPTION
## 📋 概要

調味料の種類を追加するためのカスタムフック `useSeasoningTypeAdd` を TDD アプローチで実装しました。責務分離とエラーハンドリングの観点を重視し、コンポーネント側でエラーメッセージを管理する設計としています。

## 🎯 実装内容

### 新規追加されたファイル
- **型定義**: `src/types/seasoningType.ts`
- **バリデーション**: `src/utils/seasoningTypeNameValidation.ts` + テスト
- **エラーメッセージ変換**: `src/features/seasoning/utils/seasoningTypeValidationMessage.ts` + テスト  
- **カスタムフック**: `src/hooks/useSeasoningTypeAdd.ts` + テスト

### 🔧 主要機能
- **バリデーション**: 必須チェック、文字数制限（50文字）
- **送信処理**: 非同期送信とエラーハンドリング
- **エラー管理**: ValidationErrorState と SubmitErrorState による状態管理
- **フォーム管理**: リアルタイムバリデーション、リセット機能

## 🏗️ 設計方針

### 責務分離
- **カスタムフック**: エラーの種類（enum/定数）のみを保持
- **コンポーネント**: エラーメッセージの文字列を管理
- **ユーティリティ**: エラー種別からメッセージへの変換機能

### 品質保証
- **TDD**: テスト駆動開発でカスタムフック、バリデーション、ユーティリティを実装
- **テストカバレッジ**: 計22テストケースで包括的にカバー
- **型安全性**: TypeScript で厳密な型定義

### パフォーマンス最適化
- **React Hooks最適化**: `useMemo`, `useCallback` を適切に使用
- **早期リターン**: ガード節によるコードの可読性向上
- **tidy-first**: 小さな整理による保守性向上

## 📊 テスト結果

```bash
✓ useSeasoningTypeAdd (13 tests) 
✓ validateSeasoningTypeName (7 tests)
✓ getSeasoningTypeValidationMessage (4 tests)
✓ getSeasoningTypeSubmitMessage (5 tests)

Test Files: 3 passed
Tests: 29 passed
```

## 🔍 コードレビューのポイント

1. **責務分離**: エラーメッセージ文字列がコンポーネント側の責務になっているか
2. **エラーハンドリング**: 各種エラー（ネットワーク、バリデーション、サーバー）が適切に処理されているか
3. **型安全性**: TypeScript の型定義が適切で、型の恩恵を受けられているか
4. **テスト品質**: エッジケースを含む十分なテストカバレッジがあるか
5. **React Hooks**: メモ化や依存配列が適切に設定されているか

## 🚀 今後の予定

- UI コンポーネントでの `useSeasoningTypeAdd` の使用
- エラーメッセージ変換ユーティリティの活用
- 必要に応じた他のカスタムフックとの共通化リファクタリング

---

**関連Issue**: #TBD（調味料管理機能の一部）
**影響範囲**: 新規機能のため既存機能への影響なし