### PR TITLE
🎨 [Accessibility]: Dockerファイルに日本語ロケール設定を追加

### DIFF
--- a/.devcontainer/node/Dockerfile
+++ b/.devcontainer/node/Dockerfile
@@ -3,13 +3,16 @@ FROM ubuntu:22.04
 
 # Set environment variables to prevent interactive prompts during installation
 ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=ja_JP.UTF-8
+ENV LC_ALL=ja_JP.UTF-8
 
 # Install dependencies and Node.js
 ARG NODE_MAJOR=22
 RUN apt-get update && \
-    apt-get install -y curl gnupg && \
+    apt-get install -y curl gnupg git locales fonts-noto-cjk && \
     curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
     apt-get install -y nodejs build-essential && \
+    locale-gen ja_JP.UTF-8 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user called 'node' with sudo privileges


### PR DESCRIPTION
## 概要
Dockerコンテナ内で日本語を正しく表示・入力できるようにするため、日本語ロケール設定を追加しました。

## 変更内容
- `locales`パッケージと`fonts-noto-cjk`（日本語フォント）をインストール
- `ja_JP.UTF-8`ロケールを生成・設定
- `LANG`, `LC_ALL`環境変数を日本語に設定

## 効果
- コンテナ内で日本語文字が正しく表示される
- 日本語の入力が可能になる
- 文字化けが解消される
- ターミナルでの日本語操作がスムーズになる

## 確認方法
コンテナを再構築後、以下のコマンドで確認できます：
```bash
locale
echo $LANG
```

## 関連Issue
なし（改善提案）