### PR TITLE
♻️ [Refactoring]: importパスを相対パスからエイリアスに統一

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,9 @@
       ]
     }
   },
+  "remoteEnv": {
+    "GITHUB_TOKEN": "${localEnv:GITHUB_PERSONAL_ACCESS_TOKEN}"
+  },
   "forwardPorts": [3000],
   "postCreateCommand": "npm install",
   "remoteUser": "node"

--- a/.devcontainer/node/Dockerfile
+++ b/.devcontainer/node/Dockerfile
@@ -1,3 +1,12 @@
+# Use Go 1.23 for building, then switch to Node.js for runtime
+FROM golang:1.23-bullseye AS builder
+
+# Build GitHub MCP Server
+RUN git clone https://github.com/github/github-mcp-server.git /tmp/github-mcp-server \
+    && cd /tmp/github-mcp-server \
+    && go build -o github-mcp-server ./cmd/github-mcp-server
+
+
 # Use Ubuntu as the base image
 FROM ubuntu:22.04
 
@@ -9,11 +18,14 @@ ENV LC_ALL=ja_JP.UTF-8
 # Install dependencies and Node.js
 ARG NODE_MAJOR=22
 RUN apt-get update && \
-    apt-get install -y curl gnupg git locales fonts-noto-cjk && \
+    apt-get install -y curl vim nano tree sudo wget gnupg git locales fonts-noto-cjk && \
     curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
     apt-get install -y nodejs build-essential && \
     locale-gen ja_JP.UTF-8 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy the built MCP server binary
+COPY --from=builder /tmp/github-mcp-server/github-mcp-server /usr/local/bin/
 
 # Create a non-root user called 'node' with sudo privileges
 RUN useradd -m -s /bin/bash node && \

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -7,6 +7,13 @@
         "docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN=\"$GITHUB_PERSONAL_ACCESS_TOKEN\" ghcr.io/github/github-mcp-server"
       ]
     },
+    "github-mcp": {
+      "command": "bash",
+      "args": [
+        "-c",
+        "GITHUB_PERSONAL_ACCESS_TOKEN=\"$GITHUB_TOKEN\" exec /usr/local/bin/github-mcp-server stdio"
+      ]
+    },
     "prompt-mcp-server": {
       "command": "docker",
       "args": [

--- a/src/app/api/seasonings/route.test.ts
+++ b/src/app/api/seasonings/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
-import { GET, POST } from "./route";
+import { GET, POST } from "@/app/api/seasonings/route";
 
 // テスト用のモックリクエスト作成関数
 const createRequest = (

--- a/src/app/api/seasonings/route.ts
+++ b/src/app/api/seasonings/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { seasoningAddRequestSchema } from "../../../types/api/seasoning/add/schemas";
-import type { ErrorResponse } from "../../../types/api/common/types";
+import { seasoningAddRequestSchema } from "@/app/api/../../types/api/seasoning/add/schemas";
+import type { ErrorResponse } from "@/app/api/../../types/api/common/types";
 
 // 調味料の型定義（新しい形式）
 interface Seasoning {

--- a/src/app/seasoning/add/page.tsx
+++ b/src/app/seasoning/add/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import React from "react";
-import { SeasoningAddForm } from "../../../components/forms/seasoning/SeasoningAddForm";
-import { FormData } from "../../../hooks/useSeasoningSubmit";
-import { useSeasoningNavigation } from "../../../hooks/useSeasoningNavigation";
-import { Button } from "../../../components/elements/buttons/button";
+import { SeasoningAddForm } from "@/app/seasoning/../../components/forms/seasoning/SeasoningAddForm";
+import { FormData } from "@/app/seasoning/../../hooks/useSeasoningSubmit";
+import { useSeasoningNavigation } from "@/app/seasoning/../../hooks/useSeasoningNavigation";
+import { Button } from "@/app/seasoning/../../components/elements/buttons/button";
 
 /**
  * 調味料追加ページコンポーネント

--- a/src/app/seasoning/list/page.tsx
+++ b/src/app/seasoning/list/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import React from "react";
-import { Button } from "../../../components/elements/buttons/button";
-import { useSeasoningNavigation } from "../../../hooks/useSeasoningNavigation";
+import { Button } from "@/app/seasoning/../../components/elements/buttons/button";
+import { useSeasoningNavigation } from "@/app/seasoning/../../hooks/useSeasoningNavigation";
 
 /**
  * 調味料一覧ページコンポーネント

--- a/src/app/template/add/page.tsx
+++ b/src/app/template/add/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import React from "react";
-import { TemplateAddForm } from "../../../components/forms/template/TemplateAddForm";
-import { TemplateFormData } from "../../../hooks/useTemplateSubmit";
+import { TemplateAddForm } from "@/app/template/../../components/forms/template/TemplateAddForm";
+import { TemplateFormData } from "@/app/template/../../hooks/useTemplateSubmit";
 
 /**
  * テンプレート追加ページコンポーネント

--- a/src/components/elements/buttons/Button.stories.tsx
+++ b/src/components/elements/buttons/Button.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Button } from './button';
+import { Button } from '@/components/elements/buttons/button';
 
 const meta: Meta<typeof Button> = {
   title: 'Elements/Button',

--- a/src/components/elements/inputs/TextInput.stories.tsx
+++ b/src/components/elements/inputs/TextInput.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { TextInput } from './TextInput';
+import { TextInput } from '@/components/elements/inputs/TextInput';
 import { useState } from 'react';
 
 const meta: Meta<typeof TextInput> = {

--- a/src/components/forms/seasoning/SeasoningAddForm.stories.tsx
+++ b/src/components/forms/seasoning/SeasoningAddForm.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { SeasoningAddForm } from './SeasoningAddForm';
+import { SeasoningAddForm } from '@/components/forms/seasoning/SeasoningAddForm';
 import { FormData } from '@/hooks/useSeasoningSubmit';
 
 const meta: Meta<typeof SeasoningAddForm> = {

--- a/src/components/forms/seasoning/SeasoningAddForm.test.tsx
+++ b/src/components/forms/seasoning/SeasoningAddForm.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { SeasoningAddForm } from "./SeasoningAddForm";
+import { SeasoningAddForm } from "@/components/forms/seasoning/SeasoningAddForm";
 import { vi } from "vitest";
 
 describe("SeasoningAddForm", () => {

--- a/src/components/forms/seasoning/SeasoningAddForm.tsx
+++ b/src/components/forms/seasoning/SeasoningAddForm.tsx
@@ -57,7 +57,7 @@ export const SeasoningAddForm = ({ onSubmit }: Props): React.JSX.Element => {
   const formData = { image: seasoningImage.value };
 
   // フォーム送信用のカスタムフック
-  const { submit, isSubmitting, errors, isFormValid, setImageError } =
+  const { submit, isSubmitting, errors, isFormValid } =
     useSeasoningSubmit(
       seasoningName,
       seasoningType,
@@ -75,10 +75,7 @@ export const SeasoningAddForm = ({ onSubmit }: Props): React.JSX.Element => {
     const file = e.target.files?.[0] || null;
     seasoningImage.onChange(file);
 
-    // カスタムフックのエラーを外部エラーに同期
-    if (seasoningImage.error) {
-      setImageError(seasoningImage.error);
-    }
+    // 画像バリデーションは内部で処理されるため、ここではsetImageErrorは不要
   };
 
   return (
@@ -92,7 +89,9 @@ export const SeasoningAddForm = ({ onSubmit }: Props): React.JSX.Element => {
       aria-label="調味料追加フォーム"
     >
       {/* 全般的なエラーメッセージ */}
-      {errors.general ? <ErrorMessage message={errors.general} /> : null}
+      {errors.general && errors.general !== "NONE" ? (
+        <ErrorMessage message={errors.general} />
+      ) : null}
 
       {/* 名前フィールド */}
       <TextInput
@@ -105,8 +104,8 @@ export const SeasoningAddForm = ({ onSubmit }: Props): React.JSX.Element => {
         placeholder="調味料名を入力"
         maxLength={VALIDATION_CONSTANTS.NAME_MAX_LENGTH}
         required={true}
-        errorMessage={seasoningName.error}
-        aria-describedby={seasoningName.error ? "name-error" : undefined}
+        errorMessage={seasoningName.error !== "NONE" ? seasoningName.error : ""}
+        aria-describedby={seasoningName.error !== "NONE" ? "name-error" : undefined}
       />
 
       {/* 種類フィールド */}
@@ -119,8 +118,8 @@ export const SeasoningAddForm = ({ onSubmit }: Props): React.JSX.Element => {
         onBlur={seasoningType.onBlur}
         options={SEASONING_TYPES}
         required={true}
-        errorMessage={seasoningType.error}
-        aria-describedby={seasoningType.error ? "type-error" : undefined}
+        errorMessage={seasoningType.error !== "NONE" ? seasoningType.error : ""}
+        aria-describedby={seasoningType.error !== "NONE" ? "type-error" : undefined}
       />
 
       {/* 画像フィールド */}
@@ -130,10 +129,18 @@ export const SeasoningAddForm = ({ onSubmit }: Props): React.JSX.Element => {
         label="調味料の画像"
         onChange={handleFileChange}
         accept={VALIDATION_CONSTANTS.IMAGE_VALID_TYPES.join(",")}
-        errorMessage={seasoningImage.error || errors.image}
+        errorMessage={
+          seasoningImage.error !== "NONE" 
+            ? seasoningImage.error
+            : errors.image !== "NONE" 
+            ? errors.image
+            : ""
+        }
         helperText={`JPEG または PNG 形式、${VALIDATION_CONSTANTS.IMAGE_MAX_SIZE_MB}MB以下`}
         aria-describedby={
-          seasoningImage.error || errors.image ? "image-error" : "image-help"
+          seasoningImage.error !== "NONE" || errors.image !== "NONE"
+            ? "image-error"
+            : "image-help"
         }
       />
 

--- a/src/components/forms/seasoning/SeasoningAddForm.tsx
+++ b/src/components/forms/seasoning/SeasoningAddForm.tsx
@@ -1,17 +1,17 @@
 import React, { ChangeEvent } from "react";
-import { ErrorMessage } from "../../elements/errors/ErrorMessage";
-import { TextInput } from "../../elements/inputs/TextInput";
-import { SelectInput } from "../../elements/inputs/SelectInput";
-import { FileInput } from "../../elements/inputs/FileInput";
-import { SubmitButton } from "../../elements/buttons/SubmitButton";
-import { useSeasoningNameInput } from "../../../hooks/useSeasoningNameInput";
-import { useSeasoningTypeInput } from "../../../hooks/useSeasoningTypeInput";
-import { useSeasoningImageInput } from "../../../hooks/useSeasoningImageInput";
+import { ErrorMessage } from "@/components/forms/../elements/errors/ErrorMessage";
+import { TextInput } from "@/components/forms/../elements/inputs/TextInput";
+import { SelectInput } from "@/components/forms/../elements/inputs/SelectInput";
+import { FileInput } from "@/components/forms/../elements/inputs/FileInput";
+import { SubmitButton } from "@/components/forms/../elements/buttons/SubmitButton";
+import { useSeasoningNameInput } from "@/components/forms/../../hooks/useSeasoningNameInput";
+import { useSeasoningTypeInput } from "@/components/forms/../../hooks/useSeasoningTypeInput";
+import { useSeasoningImageInput } from "@/components/forms/../../hooks/useSeasoningImageInput";
 import {
   useSeasoningSubmit,
   FormData,
-} from "../../../hooks/useSeasoningSubmit";
-import { VALIDATION_CONSTANTS } from "../../../constants/validation";
+} from "@/components/forms/../../hooks/useSeasoningSubmit";
+import { VALIDATION_CONSTANTS } from "@/components/forms/../../constants/validation";
 
 /**
  * 調味料の種類定義

--- a/src/components/forms/seasoning/SeasoningAddFormExample.tsx
+++ b/src/components/forms/seasoning/SeasoningAddFormExample.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SeasoningAddForm } from './SeasoningAddForm';
+import { SeasoningAddForm } from '@/components/forms/seasoning/SeasoningAddForm';
 
 interface FormData {
   name: string;

--- a/src/components/forms/template/TemplateAddForm.stories.tsx
+++ b/src/components/forms/template/TemplateAddForm.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { TemplateAddForm } from "./TemplateAddForm";
-import { TemplateFormData } from "../../../hooks/useTemplateSubmit";
+import { TemplateAddForm } from "@/components/forms/template/TemplateAddForm";
+import { TemplateFormData } from "@/components/forms/../../hooks/useTemplateSubmit";
 
 const meta: Meta<typeof TemplateAddForm> = {
   title: "Forms/Template/TemplateAddForm",

--- a/src/components/forms/template/TemplateAddForm.test.tsx
+++ b/src/components/forms/template/TemplateAddForm.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { TemplateAddForm } from "./TemplateAddForm";
+import { TemplateAddForm } from "@/components/forms/template/TemplateAddForm";
 
 describe("TemplateAddForm", () => {
   test("フォーム要素が表示される", () => {

--- a/src/components/forms/template/TemplateAddForm.tsx
+++ b/src/components/forms/template/TemplateAddForm.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import React from "react";
-import { TextInput } from "../../elements/inputs/TextInput";
-import { SubmitButton } from "../../elements/buttons/SubmitButton";
-import { ErrorMessage } from "../../elements/errors/ErrorMessage";
-import { useTemplateNameInput } from "../../../hooks/useTemplateNameInput";
-import { useTemplateDescriptionInput } from "../../../hooks/useTemplateDescriptionInput";
-import { useTemplateSeasoningSelection } from "../../../hooks/useTemplateSeasoningSelection";
+import { TextInput } from "@/components/forms/../elements/inputs/TextInput";
+import { SubmitButton } from "@/components/forms/../elements/buttons/SubmitButton";
+import { ErrorMessage } from "@/components/forms/../elements/errors/ErrorMessage";
+import { useTemplateNameInput } from "@/components/forms/../../hooks/useTemplateNameInput";
+import { useTemplateDescriptionInput } from "@/components/forms/../../hooks/useTemplateDescriptionInput";
+import { useTemplateSeasoningSelection } from "@/components/forms/../../hooks/useTemplateSeasoningSelection";
 import {
   useTemplateSubmit,
   TemplateFormData,
-} from "../../../hooks/useTemplateSubmit";
+} from "@/components/forms/../../hooks/useTemplateSubmit";
 
 /**
  * テンプレート追加フォームのProps

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -3,7 +3,7 @@
  * MySQL接続設定とプール設定を管理する
  */
 
-import { env } from "./environment";
+import { env } from "@/config/environment";
 
 /**
  * データベース接続設定の型定義

--- a/src/constants/pagePaths.test.ts
+++ b/src/constants/pagePaths.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { SEASONING_PAGE_PATHS, type SeasoningPagePath } from "./pagePaths";
+import { describe, test, expect } from "vitest";
+import { SEASONING_PAGE_PATHS, type SeasoningPagePath } from "@/constants/pagePaths";
 
 describe("SEASONING_PAGE_PATHS", () => {
   describe("ページパス定数値の確認", () => {

--- a/src/constants/pagePaths.test.ts
+++ b/src/constants/pagePaths.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from "vitest";
-import { SEASONING_PAGE_PATHS, type SeasoningPagePath } from "@/constants/pagePaths";
+import {
+  SEASONING_PAGE_PATHS,
+  type SeasoningPagePath,
+} from "@/constants/pagePaths";
 
 describe("SEASONING_PAGE_PATHS", () => {
   describe("ページパス定数値の確認", () => {

--- a/src/constants/validation.test.ts
+++ b/src/constants/validation.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from "vitest";
-import { VALIDATION_ERROR_MESSAGES, VALIDATION_CONSTANTS } from "@/constants/validation";
+import {
+  VALIDATION_ERROR_MESSAGES,
+  VALIDATION_CONSTANTS,
+} from "@/constants/validation";
 
 describe("validation constants", () => {
   describe("VALIDATION_ERROR_MESSAGES (ネストされた構造)", () => {

--- a/src/constants/validation.test.ts
+++ b/src/constants/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { VALIDATION_ERROR_MESSAGES, VALIDATION_CONSTANTS } from "./validation";
+import { VALIDATION_ERROR_MESSAGES, VALIDATION_CONSTANTS } from "@/constants/validation";
 
 describe("validation constants", () => {
   describe("VALIDATION_ERROR_MESSAGES (ネストされた構造)", () => {

--- a/src/features/seasoning/utils/imageValidationMessage.ts
+++ b/src/features/seasoning/utils/imageValidationMessage.ts
@@ -1,8 +1,8 @@
-import type { ImageValidationError } from "@/features/seasoning/../../utils/imageValidation";
+import type { ImageValidationError } from "@/utils/imageValidation";
 import {
   VALIDATION_CONSTANTS,
   VALIDATION_ERROR_MESSAGES,
-} from "@/features/seasoning/../../constants/validation";
+} from "@/constants/validation";
 
 /**
  * 画像バリデーションエラーのメッセージ表示

--- a/src/features/seasoning/utils/imageValidationMessage.ts
+++ b/src/features/seasoning/utils/imageValidationMessage.ts
@@ -1,8 +1,8 @@
-import type { ImageValidationError } from "../../../utils/imageValidation";
+import type { ImageValidationError } from "@/features/seasoning/../../utils/imageValidation";
 import {
   VALIDATION_CONSTANTS,
   VALIDATION_ERROR_MESSAGES,
-} from "../../../constants/validation";
+} from "@/features/seasoning/../../constants/validation";
 
 /**
  * 画像バリデーションエラーのメッセージ表示

--- a/src/features/seasoning/utils/nameValidationMessage.test.ts
+++ b/src/features/seasoning/utils/nameValidationMessage.test.ts
@@ -1,4 +1,4 @@
-import { nameValidationErrorMessage } from "./nameValidationMessage";
+import { nameValidationErrorMessage } from "@/features/seasoning/utils/nameValidationMessage";
 
 describe("nameValidationErrorMessage", () => {
   test("REQUIRED エラーの場合、必須メッセージを返す", () => {

--- a/src/features/seasoning/utils/nameValidationMessage.ts
+++ b/src/features/seasoning/utils/nameValidationMessage.ts
@@ -2,7 +2,7 @@ import type { NameValidationError } from "@/utils/nameValidation";
 import {
   VALIDATION_CONSTANTS,
   VALIDATION_ERROR_MESSAGES,
-} from "../../../constants/validation";
+} from "@/features/seasoning/../../constants/validation";
 
 /**
  * 調味料名バリデーションエラーのメッセージ表示

--- a/src/features/seasoning/utils/nameValidationMessage.ts
+++ b/src/features/seasoning/utils/nameValidationMessage.ts
@@ -1,4 +1,4 @@
-import type { NameValidationError } from "../../../utils/nameValidation";
+import type { NameValidationError } from "@/utils/nameValidation";
 import {
   VALIDATION_CONSTANTS,
   VALIDATION_ERROR_MESSAGES,

--- a/src/features/seasoning/utils/nameValidationMessage.ts
+++ b/src/features/seasoning/utils/nameValidationMessage.ts
@@ -2,7 +2,7 @@ import type { NameValidationError } from "@/utils/nameValidation";
 import {
   VALIDATION_CONSTANTS,
   VALIDATION_ERROR_MESSAGES,
-} from "@/features/seasoning/../../constants/validation";
+} from "@/constants/validation";
 
 /**
  * 調味料名バリデーションエラーのメッセージ表示

--- a/src/features/seasoning/utils/seasoningTypeValidationMessage.test.ts
+++ b/src/features/seasoning/utils/seasoningTypeValidationMessage.test.ts
@@ -2,12 +2,12 @@ import { describe, test, expect } from "vitest";
 import {
   getSeasoningTypeValidationMessage,
   getSeasoningTypeSubmitMessage,
-} from "./seasoningTypeValidationMessage";
+} from "@/features/seasoning/utils/seasoningTypeValidationMessage";
 import {
   VALIDATION_ERROR_STATES,
   type ValidationErrorState,
-} from "../../../types/validationErrorState";
-import { SUBMIT_ERROR_STATES } from "../../../types/submitErrorState";
+} from "@/features/seasoning/../../types/validationErrorState";
+import { SUBMIT_ERROR_STATES } from "@/features/seasoning/../../types/submitErrorState";
 
 describe("getSeasoningTypeValidationMessage", () => {
   test("REQUIREDエラーの場合、必須メッセージを返す", () => {

--- a/src/features/seasoning/utils/seasoningTypeValidationMessage.test.ts
+++ b/src/features/seasoning/utils/seasoningTypeValidationMessage.test.ts
@@ -6,8 +6,8 @@ import {
 import {
   VALIDATION_ERROR_STATES,
   type ValidationErrorState,
-} from "@/features/seasoning/../../types/validationErrorState";
-import { SUBMIT_ERROR_STATES } from "@/features/seasoning/../../types/submitErrorState";
+} from "@/types/validationErrorState";
+import { SUBMIT_ERROR_STATES } from "@/types/submitErrorState";
 
 describe("getSeasoningTypeValidationMessage", () => {
   test("REQUIREDエラーの場合、必須メッセージを返す", () => {

--- a/src/features/seasoning/utils/seasoningTypeValidationMessage.ts
+++ b/src/features/seasoning/utils/seasoningTypeValidationMessage.ts
@@ -1,5 +1,5 @@
-import type { ValidationErrorState } from "../../../types/validationErrorState";
-import type { SubmitErrorState } from "../../../types/submitErrorState";
+import type { ValidationErrorState } from "@/features/seasoning/../../types/validationErrorState";
+import type { SubmitErrorState } from "@/features/seasoning/../../types/submitErrorState";
 
 /**
  * 調味料の種類追加時のバリデーションエラーメッセージを取得

--- a/src/features/seasoning/utils/seasoningTypeValidationMessage.ts
+++ b/src/features/seasoning/utils/seasoningTypeValidationMessage.ts
@@ -1,5 +1,5 @@
-import type { ValidationErrorState } from "@/features/seasoning/../../types/validationErrorState";
-import type { SubmitErrorState } from "@/features/seasoning/../../types/submitErrorState";
+import type { ValidationErrorState } from "@/types/validationErrorState";
+import type { SubmitErrorState } from "@/types/submitErrorState";
 
 /**
  * 調味料の種類追加時のバリデーションエラーメッセージを取得

--- a/src/features/seasoning/utils/typeValidationMessage.test.ts
+++ b/src/features/seasoning/utils/typeValidationMessage.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { typeValidationErrorMessage } from "./typeValidationMessage";
+import { typeValidationErrorMessage } from "@/features/seasoning/utils/typeValidationMessage";
 
 describe("typeValidationErrorMessage", () => {
   test("REQUIREDエラーの場合に適切なメッセージを返す", () => {

--- a/src/features/seasoning/utils/typeValidationMessage.ts
+++ b/src/features/seasoning/utils/typeValidationMessage.ts
@@ -1,4 +1,4 @@
-import type { TypeValidationError } from "../../../utils/typeValidation";
+import type { TypeValidationError } from "@/features/seasoning/../../utils/typeValidation";
 
 /**
  * タイプバリデーションエラーのメッセージ表示

--- a/src/features/seasoning/utils/typeValidationMessage.ts
+++ b/src/features/seasoning/utils/typeValidationMessage.ts
@@ -1,4 +1,4 @@
-import type { TypeValidationError } from "@/features/seasoning/../../utils/typeValidation";
+import type { TypeValidationError } from "@/utils/typeValidation";
 
 /**
  * タイプバリデーションエラーのメッセージ表示

--- a/src/features/template/utils/nameValidationMessage.test.ts
+++ b/src/features/template/utils/nameValidationMessage.test.ts
@@ -1,4 +1,4 @@
-import { getTemplateNameValidationMessage } from "./nameValidationMessage";
+import { getTemplateNameValidationMessage } from "@/features/template/utils/nameValidationMessage";
 
 describe("getTemplateNameValidationMessage", () => {
   test("有効な名前の場合は空文字を返す", () => {

--- a/src/features/template/utils/nameValidationMessage.ts
+++ b/src/features/template/utils/nameValidationMessage.ts
@@ -1,5 +1,3 @@
-import { validateTemplateName } from "@/utils/templateNameValidation";
-
 /**
  * テンプレート名のバリデーションメッセージを取得する
  * @param name - バリデーション対象のテンプレート名

--- a/src/features/template/utils/nameValidationMessage.ts
+++ b/src/features/template/utils/nameValidationMessage.ts
@@ -1,4 +1,4 @@
-import { validateTemplateName } from "../../../utils/templateNameValidation";
+import { validateTemplateName } from "@/utils/templateNameValidation";
 
 /**
  * テンプレート名のバリデーションメッセージを取得する

--- a/src/hooks/useSeasoningImageInput.test.ts
+++ b/src/hooks/useSeasoningImageInput.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from "@testing-library/react";
-import { useSeasoningImageInput } from "./useSeasoningImageInput";
+import { useSeasoningImageInput } from "@/hooks/useSeasoningImageInput";
 
 describe("useSeasoningImageInput", () => {
   test("初期値がnullでエラーがないこと", () => {

--- a/src/hooks/useSeasoningImageInput.ts
+++ b/src/hooks/useSeasoningImageInput.ts
@@ -2,9 +2,9 @@ import { useState } from "react";
 import {
   validateImage,
   type ImageValidationError,
-} from "../utils/imageValidation";
-import type { ValidationErrorState } from "../types/validationErrorState";
-import { VALIDATION_ERROR_STATES } from "../types/validationErrorState";
+} from "@/utils/imageValidation";
+import type { ValidationErrorState } from "@/types/validationErrorState";
+import { VALIDATION_ERROR_STATES } from "@/types/validationErrorState";
 
 export interface UseSeasoningImageInputReturn {
   value: File | null;

--- a/src/hooks/useSeasoningImageInput.ts
+++ b/src/hooks/useSeasoningImageInput.ts
@@ -3,12 +3,13 @@ import {
   validateImage,
   type ImageValidationError,
 } from "@/utils/imageValidation";
+import { imageValidationErrorMessage } from "@/features/seasoning/utils/imageValidationMessage";
 import type { ValidationErrorState } from "@/types/validationErrorState";
 import { VALIDATION_ERROR_STATES } from "@/types/validationErrorState";
 
 export interface UseSeasoningImageInputReturn {
   value: File | null;
-  error: ValidationErrorState;
+  error: string;
   onChange: (file: File | null) => void;
   reset: () => void;
   setError: (error: ValidationErrorState) => void;
@@ -20,9 +21,22 @@ export interface UseSeasoningImageInputReturn {
  */
 export const useSeasoningImageInput = (): UseSeasoningImageInputReturn => {
   const [value, setValue] = useState<File | null>(null);
-  const [error, setError] = useState<ValidationErrorState>(
+  const [errorState, setErrorState] = useState<ValidationErrorState>(
     VALIDATION_ERROR_STATES.NONE
   );
+
+  // ValidationErrorStateから実際のバリデーションエラーを逆変換
+  const getValidationErrorFromState = (state: ValidationErrorState): ImageValidationError => {
+    switch (state) {
+      case VALIDATION_ERROR_STATES.INVALID_FILE_TYPE:
+        return "INVALID_TYPE";
+      case VALIDATION_ERROR_STATES.FILE_TOO_LARGE:
+        return "SIZE_EXCEEDED";
+      case VALIDATION_ERROR_STATES.NONE:
+      default:
+        return "NONE";
+    }
+  };
 
   // バリデーション結果をValidationErrorStateに変換
   const convertValidationError = (
@@ -47,8 +61,8 @@ export const useSeasoningImageInput = (): UseSeasoningImageInputReturn => {
   const onChange = (file: File | null) => {
     setValue(file);
     const validationError = validateImage(file);
-    const errorState = convertValidationError(validationError);
-    setError(errorState);
+    const newErrorState = convertValidationError(validationError);
+    setErrorState(newErrorState);
   };
 
   /**
@@ -56,12 +70,20 @@ export const useSeasoningImageInput = (): UseSeasoningImageInputReturn => {
    */
   const reset = () => {
     setValue(null);
-    setError(VALIDATION_ERROR_STATES.NONE);
+    setErrorState(VALIDATION_ERROR_STATES.NONE);
+  };
+
+  /**
+   * エラー状態を設定
+   * @param error - 設定するエラー状態
+   */
+  const setError = (error: ValidationErrorState) => {
+    setErrorState(error);
   };
 
   return {
     value,
-    error,
+    error: imageValidationErrorMessage(getValidationErrorFromState(errorState)),
     onChange,
     reset,
     setError,

--- a/src/hooks/useSeasoningNameInput.test.ts
+++ b/src/hooks/useSeasoningNameInput.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react';
-import { useSeasoningNameInput } from './useSeasoningNameInput';
+import { useSeasoningNameInput } from '@/hooks/useSeasoningNameInput';
 
 describe('useSeasoningNameInput', () => {
   test('初期値が空文字でエラーがないこと', () => {

--- a/src/hooks/useSeasoningNameInput.ts
+++ b/src/hooks/useSeasoningNameInput.ts
@@ -2,9 +2,9 @@ import { useState, ChangeEvent, FocusEvent } from "react";
 import {
   validateSeasoningName,
   type NameValidationError,
-} from "../utils/nameValidation";
-import type { ValidationErrorState } from "../types/validationErrorState";
-import { VALIDATION_ERROR_STATES } from "../types/validationErrorState";
+} from "@/utils/nameValidation";
+import type { ValidationErrorState } from "@/types/validationErrorState";
+import { VALIDATION_ERROR_STATES } from "@/types/validationErrorState";
 
 export interface UseSeasoningNameInputReturn {
   value: string;

--- a/src/hooks/useSeasoningNameInput.ts
+++ b/src/hooks/useSeasoningNameInput.ts
@@ -3,12 +3,13 @@ import {
   validateSeasoningName,
   type NameValidationError,
 } from "@/utils/nameValidation";
+import { nameValidationErrorMessage } from "@/features/seasoning/utils/nameValidationMessage";
 import type { ValidationErrorState } from "@/types/validationErrorState";
 import { VALIDATION_ERROR_STATES } from "@/types/validationErrorState";
 
 export interface UseSeasoningNameInputReturn {
   value: string;
-  error: ValidationErrorState;
+  error: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onBlur: (e: FocusEvent<HTMLInputElement>) => void;
   reset: () => void;
@@ -20,7 +21,7 @@ export interface UseSeasoningNameInputReturn {
  */
 export const useSeasoningNameInput = (): UseSeasoningNameInputReturn => {
   const [value, setValue] = useState("");
-  const [error, setError] = useState<ValidationErrorState>(
+  const [errorState, setErrorState] = useState<ValidationErrorState>(
     VALIDATION_ERROR_STATES.NONE
   );
 
@@ -48,8 +49,8 @@ export const useSeasoningNameInput = (): UseSeasoningNameInputReturn => {
 
     // 変更時にフィールドをバリデーション
     const validationError = validateSeasoningName(newValue);
-    const errorState = convertValidationError(validationError);
-    setError(errorState);
+    const newErrorState = convertValidationError(validationError);
+    setErrorState(newErrorState);
   };
 
   // バリデーションのためのブラーイベントの処理
@@ -58,19 +59,34 @@ export const useSeasoningNameInput = (): UseSeasoningNameInputReturn => {
 
     // ブラー時にフィールドをバリデーション
     const validationError = validateSeasoningName(currentValue);
-    const errorState = convertValidationError(validationError);
-    setError(errorState);
+    const newErrorState = convertValidationError(validationError);
+    setErrorState(newErrorState);
   };
 
   // 値とエラーをクリアするリセット関数
   const reset = () => {
     setValue("");
-    setError(VALIDATION_ERROR_STATES.NONE);
+    setErrorState(VALIDATION_ERROR_STATES.NONE);
+  };
+
+  // ValidationErrorStateから実際のバリデーションエラーを逆変換
+  const getValidationErrorFromState = (state: ValidationErrorState): NameValidationError => {
+    switch (state) {
+      case VALIDATION_ERROR_STATES.REQUIRED:
+        return "REQUIRED";
+      case VALIDATION_ERROR_STATES.TOO_LONG:
+        return "LENGTH_EXCEEDED";
+      case VALIDATION_ERROR_STATES.INVALID_FORMAT:
+        return "INVALID_FORMAT";
+      case VALIDATION_ERROR_STATES.NONE:
+      default:
+        return "NONE";
+    }
   };
 
   return {
     value,
-    error,
+    error: nameValidationErrorMessage(getValidationErrorFromState(errorState)),
     onChange,
     onBlur,
     reset,

--- a/src/hooks/useSeasoningNavigation.test.ts
+++ b/src/hooks/useSeasoningNavigation.test.ts
@@ -1,8 +1,8 @@
 import { renderHook, act } from "@testing-library/react";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import { useRouter } from "next/navigation";
-import { useSeasoningNavigation } from "./useSeasoningNavigation";
-import { SEASONING_PAGE_PATHS } from "../constants/pagePaths";
+import { useSeasoningNavigation } from "@/hooks/useSeasoningNavigation";
+import { SEASONING_PAGE_PATHS } from "@/constants/pagePaths";
 
 // Next.jsのuseRouterをモック化
 vi.mock("next/navigation", () => ({

--- a/src/hooks/useSeasoningNavigation.ts
+++ b/src/hooks/useSeasoningNavigation.ts
@@ -1,5 +1,5 @@
 import { useRouter } from "next/navigation";
-import { SEASONING_PAGE_PATHS } from "../constants/pagePaths";
+import { SEASONING_PAGE_PATHS } from "@/constants/pagePaths";
 
 /**
  * 調味料関連の画面遷移を管理するカスタムフック

--- a/src/hooks/useSeasoningSubmit.basic.test.ts
+++ b/src/hooks/useSeasoningSubmit.basic.test.ts
@@ -7,7 +7,7 @@ import { vi } from "vitest";
 // モックの作成
 const createMockSeasoningNameInput = (
   value = "",
-  error = ""
+  error = "NONE"
 ): UseSeasoningNameInputReturn => ({
   value,
   error,
@@ -18,7 +18,7 @@ const createMockSeasoningNameInput = (
 
 const createMockSeasoningTypeInput = (
   value = "",
-  error = ""
+  error = "NONE"
 ): UseSeasoningTypeInputReturn => ({
   value,
   error,
@@ -28,7 +28,7 @@ const createMockSeasoningTypeInput = (
 });
 
 // モック作成
-vi.mock("../utils/imageValidation", () => ({
+vi.mock("@/utils/imageValidation", () => ({
   validateImage: vi.fn(() => "NONE"),
 }));
 
@@ -47,14 +47,14 @@ describe("useSeasoningSubmit - 基本テスト", () => {
     );
 
     expect(result.current.isSubmitting).toBe(false);
-    expect(result.current.errors.image).toBeNull();
-    expect(result.current.errors.general).toBeNull();
+    expect(result.current.errors.image).toBe("NONE");
+    expect(result.current.errors.general).toBe("NONE");
     expect(result.current.isFormValid).toBe(false);
   });
 
   test("エラー種別を正しく設定できること", () => {
-    const mockSeasoningName = createMockSeasoningNameInput("テスト", "");
-    const mockSeasoningType = createMockSeasoningTypeInput("タイプ", "");
+    const mockSeasoningName = createMockSeasoningNameInput("テスト", "NONE");
+    const mockSeasoningType = createMockSeasoningTypeInput("タイプ", "NONE");
     const mockFormData = { image: null };
 
     const { result } = renderHook(() =>
@@ -66,12 +66,12 @@ describe("useSeasoningSubmit - 基本テスト", () => {
     });
 
     expect(result.current.errors.image).toBe("INVALID_FILE_TYPE");
-    expect(result.current.errors.general).toBeNull();
+    expect(result.current.errors.general).toBe("NONE");
   });
 
   test("送信エラーが適切に処理されること", async () => {
-    const mockSeasoningName = createMockSeasoningNameInput("テスト", "");
-    const mockSeasoningType = createMockSeasoningTypeInput("タイプ", "");
+    const mockSeasoningName = createMockSeasoningNameInput("テスト", "NONE");
+    const mockSeasoningType = createMockSeasoningTypeInput("タイプ", "NONE");
     const mockFormData = { image: null };
     const mockOnSubmit = vi.fn().mockRejectedValue(new Error("Test error"));
 
@@ -93,8 +93,8 @@ describe("useSeasoningSubmit - 基本テスト", () => {
   });
 
   test("ネットワークエラーを正しく識別すること", async () => {
-    const mockSeasoningName = createMockSeasoningNameInput("テスト", "");
-    const mockSeasoningType = createMockSeasoningTypeInput("タイプ", "");
+    const mockSeasoningName = createMockSeasoningNameInput("テスト", "NONE");
+    const mockSeasoningType = createMockSeasoningTypeInput("タイプ", "NONE");
     const mockFormData = { image: null };
 
     const networkError = new Error("Network failed");

--- a/src/hooks/useSeasoningSubmit.basic.test.ts
+++ b/src/hooks/useSeasoningSubmit.basic.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act } from "@testing-library/react";
-import { useSeasoningSubmit } from "./useSeasoningSubmit";
-import { UseSeasoningNameInputReturn } from "./useSeasoningNameInput";
-import { UseSeasoningTypeInputReturn } from "./useSeasoningTypeInput";
+import { useSeasoningSubmit } from "@/hooks/useSeasoningSubmit";
+import { UseSeasoningNameInputReturn } from "@/hooks/useSeasoningNameInput";
+import { UseSeasoningTypeInputReturn } from "@/hooks/useSeasoningTypeInput";
 import { vi } from "vitest";
 
 // モックの作成

--- a/src/hooks/useSeasoningSubmit.test.ts
+++ b/src/hooks/useSeasoningSubmit.test.ts
@@ -1,11 +1,11 @@
 import { renderHook, act } from "@testing-library/react";
-import { useSeasoningSubmit } from "./useSeasoningSubmit";
-import { UseSeasoningNameInputReturn } from "./useSeasoningNameInput";
-import { UseSeasoningTypeInputReturn } from "./useSeasoningTypeInput";
-import { vi } from "vitest";
-import { VALIDATION_ERROR_STATES } from "../types/validationErrorState";
-import type { ValidationErrorState } from "../types/validationErrorState";
-import { SUBMIT_ERROR_STATES } from "../types/submitErrorState";
+import { useSeasoningSubmit } from "@/hooks/useSeasoningSubmit";
+import { UseSeasoningNameInputReturn } from "@/hooks/useSeasoningNameInput";
+import { UseSeasoningTypeInputReturn } from "@/hooks/useSeasoningTypeInput";
+import { beforeEach, vi } from "vitest";
+import { VALIDATION_ERROR_STATES } from "@/types/validationErrorState";
+import type { ValidationErrorState } from "@/types/validationErrorState";
+import { SUBMIT_ERROR_STATES } from "@/types/submitErrorState";
 
 // モックの作成
 const createMockSeasoningNameInput = (

--- a/src/hooks/useSeasoningSubmit.test.ts
+++ b/src/hooks/useSeasoningSubmit.test.ts
@@ -31,7 +31,7 @@ const createMockSeasoningTypeInput = (
 });
 
 // モック作成
-vi.mock("../utils/imageValidation", () => ({
+vi.mock("@/utils/imageValidation", () => ({
   validateImage: vi.fn(),
 }));
 
@@ -179,7 +179,7 @@ describe("useSeasoningSubmit", () => {
 
   describe("リファクタリング後の単一責任テスト", () => {
     test("バリデーション処理が独立して動作すること", async () => {
-      const { validateImage } = await import("../utils/imageValidation");
+      const { validateImage } = await import("@/utils/imageValidation");
 
       const mockValidateImage = vi.mocked(validateImage);
 
@@ -211,7 +211,7 @@ describe("useSeasoningSubmit", () => {
     });
 
     test("フォーム状態リセット機能が独立して動作すること", async () => {
-      const { validateImage } = await import("../utils/imageValidation");
+      const { validateImage } = await import("@/utils/imageValidation");
 
       const mockValidateImage = vi.mocked(validateImage);
 
@@ -262,7 +262,7 @@ describe("useSeasoningSubmit", () => {
     });
 
     test("エラーメッセージが定数から取得されること", async () => {
-      const { validateImage } = await import("../utils/imageValidation");
+      const { validateImage } = await import("@/utils/imageValidation");
 
       const mockValidateImage = vi.mocked(validateImage);
 
@@ -301,7 +301,7 @@ describe("useSeasoningSubmit", () => {
     });
 
     test("バリデーション関数が適切な引数で呼び出されること", async () => {
-      const { validateImage } = await import("../utils/imageValidation");
+      const { validateImage } = await import("@/utils/imageValidation");
 
       const mockValidateImage = vi.mocked(validateImage);
 
@@ -344,7 +344,7 @@ describe("useSeasoningSubmit", () => {
       const mockOnSubmit = vi.fn().mockResolvedValue(undefined);
       const mockOnReset = vi.fn();
 
-      const { validateImage } = await import("../utils/imageValidation");
+      const { validateImage } = await import("@/utils/imageValidation");
 
       const mockValidateImage = vi.mocked(validateImage);
 
@@ -387,7 +387,7 @@ describe("useSeasoningSubmit", () => {
         .fn()
         .mockRejectedValue(new Error("ネットワークエラー"));
 
-      const { validateImage } = await import("../utils/imageValidation");
+      const { validateImage } = await import("@/utils/imageValidation");
 
       const mockValidateImage = vi.mocked(validateImage);
 

--- a/src/hooks/useSeasoningSubmit.ts
+++ b/src/hooks/useSeasoningSubmit.ts
@@ -1,11 +1,11 @@
-import { useState, useEffect, useCallback } from "react";
-import type { SubmitErrorState } from "../types/submitErrorState";
-import type { ValidationErrorState } from "../types/validationErrorState";
-import { SUBMIT_ERROR_STATES } from "../types/submitErrorState";
-import { VALIDATION_ERROR_STATES } from "../types/validationErrorState";
-import { UseSeasoningNameInputReturn } from "./useSeasoningNameInput";
-import { UseSeasoningTypeInputReturn } from "./useSeasoningTypeInput";
-import { validateImage } from "../utils/imageValidation";
+import { useState, useCallback, useEffect } from "react";
+import type { SubmitErrorState } from "@/types/submitErrorState";
+import type { ValidationErrorState } from "@/types/validationErrorState";
+import { SUBMIT_ERROR_STATES } from "@/types/submitErrorState";
+import { VALIDATION_ERROR_STATES } from "@/types/validationErrorState";
+import { UseSeasoningNameInputReturn } from "@/hooks/useSeasoningNameInput";
+import { UseSeasoningTypeInputReturn } from "@/hooks/useSeasoningTypeInput";
+import { validateImage } from "@/utils/imageValidation";
 
 export interface FormData {
   name: string;

--- a/src/hooks/useSeasoningTypeAdd.test.ts
+++ b/src/hooks/useSeasoningTypeAdd.test.ts
@@ -1,8 +1,8 @@
 import { renderHook, act } from "@testing-library/react";
 import { vi } from "vitest";
-import { useSeasoningTypeAdd } from "./useSeasoningTypeAdd";
-import { VALIDATION_ERROR_STATES } from "../types/validationErrorState";
-import { SUBMIT_ERROR_STATES } from "../types/submitErrorState";
+import { useSeasoningTypeAdd } from "@/hooks/useSeasoningTypeAdd";
+import { VALIDATION_ERROR_STATES } from "@/types/validationErrorState";
+import { SUBMIT_ERROR_STATES } from "@/types/submitErrorState";
 
 describe("useSeasoningTypeAdd", () => {
   describe("初期状態", () => {

--- a/src/hooks/useSeasoningTypeAdd.ts
+++ b/src/hooks/useSeasoningTypeAdd.ts
@@ -2,12 +2,12 @@ import { useState, useCallback, useMemo, ChangeEvent, FocusEvent } from "react";
 import {
   validateSeasoningTypeName,
   type SeasoningTypeNameValidationError,
-} from "../utils/seasoningTypeNameValidation";
-import type { SeasoningTypeFormData } from "../types/seasoningType";
-import type { ValidationErrorState } from "../types/validationErrorState";
-import { VALIDATION_ERROR_STATES } from "../types/validationErrorState";
-import type { SubmitErrorState } from "../types/submitErrorState";
-import { SUBMIT_ERROR_STATES } from "../types/submitErrorState";
+} from "@/utils/seasoningTypeNameValidation";
+import type { SeasoningTypeFormData } from "@/types/seasoningType";
+import type { ValidationErrorState } from "@/types/validationErrorState";
+import { VALIDATION_ERROR_STATES } from "@/types/validationErrorState";
+import type { SubmitErrorState } from "@/types/submitErrorState";
+import { SUBMIT_ERROR_STATES } from "@/types/submitErrorState";
 
 // エラーハンドリング用の定数
 const ERROR_NAMES = {

--- a/src/hooks/useSeasoningTypeInput.test.ts
+++ b/src/hooks/useSeasoningTypeInput.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from "@testing-library/react";
-import { useSeasoningTypeInput } from "./useSeasoningTypeInput";
+import { useSeasoningTypeInput } from "@/hooks/useSeasoningTypeInput";
 
 describe("useSeasoningTypeInput", () => {
   test("初期値が空文字でエラーがないこと", () => {

--- a/src/hooks/useSeasoningTypeInput.ts
+++ b/src/hooks/useSeasoningTypeInput.ts
@@ -1,14 +1,12 @@
 import { useState, ChangeEvent, FocusEvent } from "react";
-import {
-  validateType,
-  type TypeValidationError,
-} from "@/utils/typeValidation";
+import { validateType, type TypeValidationError } from "@/utils/typeValidation";
+import { typeValidationErrorMessage } from "@/features/seasoning/utils/typeValidationMessage";
 import type { ValidationErrorState } from "@/types/validationErrorState";
 import { VALIDATION_ERROR_STATES } from "@/types/validationErrorState";
 
 export interface UseSeasoningTypeInputReturn {
   value: string;
-  error: ValidationErrorState;
+  error: string;
   onChange: (e: ChangeEvent<HTMLSelectElement>) => void;
   onBlur: (e: FocusEvent<HTMLSelectElement>) => void;
   reset: () => void;
@@ -20,9 +18,20 @@ export interface UseSeasoningTypeInputReturn {
  */
 export const useSeasoningTypeInput = (): UseSeasoningTypeInputReturn => {
   const [value, setValue] = useState("");
-  const [error, setError] = useState<ValidationErrorState>(
+  const [errorState, setErrorState] = useState<ValidationErrorState>(
     VALIDATION_ERROR_STATES.NONE
   );
+
+  // ValidationErrorStateから実際のバリデーションエラーを逆変換
+  const getValidationErrorFromState = (state: ValidationErrorState): TypeValidationError => {
+    switch (state) {
+      case VALIDATION_ERROR_STATES.REQUIRED:
+        return "REQUIRED";
+      case VALIDATION_ERROR_STATES.NONE:
+      default:
+        return "NONE";
+    }
+  };
 
   // バリデーション結果をValidationErrorStateに変換
   const convertValidationError = (
@@ -44,8 +53,8 @@ export const useSeasoningTypeInput = (): UseSeasoningTypeInputReturn => {
 
     // 変更時にフィールドをバリデーション
     const validationError = validateType(newValue);
-    const errorState = convertValidationError(validationError);
-    setError(errorState);
+    const newErrorState = convertValidationError(validationError);
+    setErrorState(newErrorState);
   };
 
   // バリデーションのためのブラーイベントの処理
@@ -54,19 +63,19 @@ export const useSeasoningTypeInput = (): UseSeasoningTypeInputReturn => {
 
     // ブラー時にフィールドをバリデーション
     const validationError = validateType(currentValue);
-    const errorState = convertValidationError(validationError);
-    setError(errorState);
+    const newErrorState = convertValidationError(validationError);
+    setErrorState(newErrorState);
   };
 
   // 値とエラーをクリアするリセット関数
   const reset = () => {
     setValue("");
-    setError(VALIDATION_ERROR_STATES.NONE);
+    setErrorState(VALIDATION_ERROR_STATES.NONE);
   };
 
   return {
     value,
-    error,
+    error: typeValidationErrorMessage(getValidationErrorFromState(errorState)),
     onChange,
     onBlur,
     reset,

--- a/src/hooks/useSeasoningTypeInput.ts
+++ b/src/hooks/useSeasoningTypeInput.ts
@@ -2,9 +2,9 @@ import { useState, ChangeEvent, FocusEvent } from "react";
 import {
   validateType,
   type TypeValidationError,
-} from "../utils/typeValidation";
-import type { ValidationErrorState } from "../types/validationErrorState";
-import { VALIDATION_ERROR_STATES } from "../types/validationErrorState";
+} from "@/utils/typeValidation";
+import type { ValidationErrorState } from "@/types/validationErrorState";
+import { VALIDATION_ERROR_STATES } from "@/types/validationErrorState";
 
 export interface UseSeasoningTypeInputReturn {
   value: string;

--- a/src/hooks/useTemplateDescriptionInput.test.ts
+++ b/src/hooks/useTemplateDescriptionInput.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from "@testing-library/react";
-import { useTemplateDescriptionInput } from "./useTemplateDescriptionInput";
+import { useTemplateDescriptionInput } from "@/hooks/useTemplateDescriptionInput";
 
 describe("useTemplateDescriptionInput", () => {
   test("初期値が空文字である", () => {

--- a/src/hooks/useTemplateDescriptionInput.ts
+++ b/src/hooks/useTemplateDescriptionInput.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { validateTemplateDescription } from "../utils/templateDescriptionValidation";
-import { getTemplateDescriptionValidationMessage } from "../features/template/utils/descriptionValidationMessage";
+import { validateTemplateDescription } from "@/utils/templateDescriptionValidation";
+import { getTemplateDescriptionValidationMessage } from "@/features/template/utils/descriptionValidationMessage";
 
 /**
  * テンプレート説明入力のカスタムフック

--- a/src/hooks/useTemplateNameInput.test.ts
+++ b/src/hooks/useTemplateNameInput.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from "@testing-library/react";
-import { useTemplateNameInput } from "./useTemplateNameInput";
+import { useTemplateNameInput } from "@/hooks/useTemplateNameInput";
 
 describe("useTemplateNameInput", () => {
   test("初期値が空文字である", () => {

--- a/src/hooks/useTemplateNameInput.ts
+++ b/src/hooks/useTemplateNameInput.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { validateTemplateName } from "../utils/templateNameValidation";
-import { getTemplateNameValidationMessage } from "../features/template/utils/nameValidationMessage";
+import { validateTemplateName } from "@/utils/templateNameValidation";
+import { getTemplateNameValidationMessage } from "@/features/template/utils/nameValidationMessage";
 
 /**
  * テンプレート名入力のカスタムフック

--- a/src/hooks/useTemplateSeasoningSelection.test.ts
+++ b/src/hooks/useTemplateSeasoningSelection.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from "@testing-library/react";
-import { useTemplateSeasoningSelection } from "./useTemplateSeasoningSelection";
+import { useTemplateSeasoningSelection } from "@/hooks/useTemplateSeasoningSelection";
 
 describe("useTemplateSeasoningSelection", () => {
   test("初期値が空配列である", () => {

--- a/src/hooks/useTemplateSubmit.test.ts
+++ b/src/hooks/useTemplateSubmit.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
-import { useTemplateSubmit } from "./useTemplateSubmit";
-import { SUBMIT_ERROR_STATES } from "../types/submitErrorState";
+import { useTemplateSubmit } from "@/hooks/useTemplateSubmit";
+import { SUBMIT_ERROR_STATES } from "@/types/submitErrorState";
 
 describe("useTemplateSubmit", () => {
   test("初期状態では送信中でない", () => {

--- a/src/hooks/useTemplateSubmit.ts
+++ b/src/hooks/useTemplateSubmit.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import type { SubmitErrorState } from "../types/submitErrorState";
-import { SUBMIT_ERROR_STATES } from "../types/submitErrorState";
+import type { SubmitErrorState } from "@/types/submitErrorState";
+import { SUBMIT_ERROR_STATES } from "@/types/submitErrorState";
 
 /**
  * テンプレート送信フォームデータの型定義

--- a/src/types/api/common/schemas.test.ts
+++ b/src/types/api/common/schemas.test.ts
@@ -4,38 +4,28 @@ import {
   errorResponseSchema,
   successResponseSchema,
   paginationSchema,
-} from "./schemas";
+} from "@/types/api/common/schemas";
 
 describe("Common API Schemas", () => {
   describe("errorResponseSchema", () => {
     test("有効なエラーレスポンスを受け入れる", () => {
+      const errorCodes = ["VALIDATION_ERROR", "NOT_FOUND"] as const;
+      const schema = errorResponseSchema(errorCodes);
       const validErrorResponse = {
-        error: true,
-        message: "エラーが発生しました",
-        code: "VALIDATION_ERROR",
+        result_code: "VALIDATION_ERROR",
       };
 
-      expect(() => errorResponseSchema.parse(validErrorResponse)).not.toThrow();
+      expect(() => schema.parse(validErrorResponse)).not.toThrow();
     });
 
-    test("messageが空文字の場合にバリデーションエラーになる", () => {
+    test("無効なエラーコードの場合にバリデーションエラーになる", () => {
+      const errorCodes = ["VALIDATION_ERROR", "NOT_FOUND"] as const;
+      const schema = errorResponseSchema(errorCodes);
       const invalidErrorResponse = {
-        error: true,
-        message: "",
-        code: "VALIDATION_ERROR",
+        result_code: "INVALID_CODE",
       };
 
-      expect(() => errorResponseSchema.parse(invalidErrorResponse)).toThrow();
-    });
-
-    test("errorがfalseの場合にバリデーションエラーになる", () => {
-      const invalidErrorResponse = {
-        error: false,
-        message: "エラーが発生しました",
-        code: "VALIDATION_ERROR",
-      };
-
-      expect(() => errorResponseSchema.parse(invalidErrorResponse)).toThrow();
+      expect(() => schema.parse(invalidErrorResponse)).toThrow();
     });
   });
 
@@ -48,7 +38,7 @@ describe("Common API Schemas", () => {
 
       const responseSchema = successResponseSchema(dataSchema);
       const validResponse = {
-        success: true,
+        result_code: "OK",
         data: {
           id: 1,
           name: "テスト",
@@ -58,7 +48,7 @@ describe("Common API Schemas", () => {
       expect(() => responseSchema.parse(validResponse)).not.toThrow();
     });
 
-    test("successがfalseの場合にバリデーションエラーになる", () => {
+    test("result_codeがOK以外の場合にバリデーションエラーになる", () => {
       const dataSchema = z.object({
         id: z.number(),
         name: z.string(),
@@ -66,7 +56,7 @@ describe("Common API Schemas", () => {
 
       const responseSchema = successResponseSchema(dataSchema);
       const invalidResponse = {
-        success: false,
+        result_code: "ERROR",
         data: {
           id: 1,
           name: "テスト",

--- a/src/types/api/common/types.ts
+++ b/src/types/api/common/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { paginationSchema } from "./schemas";
+import { paginationSchema } from "@/types/api/common/schemas";
 
 /**
  * 成功レスポンスの型

--- a/src/types/api/seasoning/add/schemas.test.ts
+++ b/src/types/api/seasoning/add/schemas.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import {
   seasoningAddRequestSchema,
   seasoningAddResponseSchema,
-} from "./schemas";
+} from "@/types/api/seasoning/add/schemas";
 
 describe("Seasoning Add API Schemas", () => {
   describe("seasoningAddRequestSchema", () => {

--- a/src/types/api/seasoning/add/schemas.test.ts
+++ b/src/types/api/seasoning/add/schemas.test.ts
@@ -8,7 +8,7 @@ describe("Seasoning Add API Schemas", () => {
   describe("seasoningAddRequestSchema", () => {
     test("有効な調味料追加リクエストを受け入れる", () => {
       const validRequest = {
-        name: "醤油",
+        name: "soysauce",
         seasoningTypeId: 1,
         image: null,
       };
@@ -18,7 +18,7 @@ describe("Seasoning Add API Schemas", () => {
 
     test("画像ありの調味料追加リクエストを受け入れる", () => {
       const validRequest = {
-        name: "醤油",
+        name: "soysauce",
         seasoningTypeId: 1,
         image: "base64encodedimage",
       };
@@ -48,7 +48,7 @@ describe("Seasoning Add API Schemas", () => {
 
     test("seasoningTypeIdが正の整数でない場合にバリデーションエラーになる", () => {
       const invalidRequest = {
-        name: "醤油",
+        name: "soysauce",
         seasoningTypeId: 0,
         image: null,
       };
@@ -60,7 +60,7 @@ describe("Seasoning Add API Schemas", () => {
   describe("seasoningAddResponseSchema", () => {
     test("有効な調味料追加レスポンスを受け入れる", () => {
       const validResponse = {
-        success: true,
+        result_code: "OK",
         data: {
           id: 1,
           name: "醤油",
@@ -79,7 +79,7 @@ describe("Seasoning Add API Schemas", () => {
 
     test("画像URLありのレスポンスを受け入れる", () => {
       const validResponse = {
-        success: true,
+        result_code: "OK",
         data: {
           id: 1,
           name: "醤油",
@@ -98,7 +98,7 @@ describe("Seasoning Add API Schemas", () => {
 
     test("successがfalseの場合にバリデーションエラーになる", () => {
       const invalidResponse = {
-        success: false,
+        result_code: "ERROR",
         data: {
           id: 1,
           name: "醤油",

--- a/src/types/api/seasoning/add/schemas.ts
+++ b/src/types/api/seasoning/add/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { successResponseSchema } from "../../common/schemas";
+import { successResponseSchema } from "@/types/api/common/schemas";
 
 /**
  * 調味料追加リクエストのスキーマ

--- a/src/types/api/seasoning/add/types.ts
+++ b/src/types/api/seasoning/add/types.ts
@@ -2,8 +2,8 @@ import { z } from "zod";
 import {
   seasoningAddRequestSchema,
   seasoningAddResponseSchema,
-} from "./schemas";
-import type { ApiResponse } from "../../common/types";
+} from "@/types/api/seasoning/add/schemas";
+import type { ApiResponse } from "@/types/api/seasoning/../common/types";
 
 /**
  * 調味料追加リクエストの型

--- a/src/types/api/seasoning/list/schemas.test.ts
+++ b/src/types/api/seasoning/list/schemas.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import {
   seasoningListResponseSchema,
   seasoningListQuerySchema,
-} from "./schemas";
+} from "@/types/api/seasoning/list/schemas";
 
 describe("Seasoning List API Schemas", () => {
   describe("seasoningListQuerySchema", () => {

--- a/src/types/api/seasoning/list/schemas.test.ts
+++ b/src/types/api/seasoning/list/schemas.test.ts
@@ -65,7 +65,7 @@ describe("Seasoning List API Schemas", () => {
   describe("seasoningListResponseSchema", () => {
     test("有効な調味料一覧レスポンスを受け入れる", () => {
       const validResponse = {
-        success: true,
+        result_code: "OK",
         data: {
           items: [
             {
@@ -94,7 +94,7 @@ describe("Seasoning List API Schemas", () => {
 
     test("空の一覧レスポンスを受け入れる", () => {
       const validResponse = {
-        success: true,
+        result_code: "OK",
         data: {
           items: [],
           pagination: {
@@ -113,7 +113,7 @@ describe("Seasoning List API Schemas", () => {
 
     test("successがfalseの場合にバリデーションエラーになる", () => {
       const invalidResponse = {
-        success: false,
+        result_code: "ERROR",
         data: {
           items: [],
           pagination: {

--- a/src/types/api/seasoning/list/schemas.ts
+++ b/src/types/api/seasoning/list/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { successResponseSchema, paginationSchema } from "../../common/schemas";
+import { successResponseSchema, paginationSchema } from "@/types/api/seasoning/../common/schemas";
 
 /**
  * 調味料一覧クエリパラメータのスキーマ

--- a/src/types/api/seasoning/list/types.ts
+++ b/src/types/api/seasoning/list/types.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import {
   seasoningListQuerySchema,
   seasoningListResponseSchema,
-} from "./schemas";
+} from "@/types/api/seasoning/list/schemas";
 
 /**
  * 調味料一覧クエリパラメータの型

--- a/src/types/api/template/add/schemas.test.ts
+++ b/src/types/api/template/add/schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { templateAddRequestSchema, templateAddResponseSchema } from "./schemas";
+import { templateAddRequestSchema, templateAddResponseSchema } from "@/types/api/template/add/schemas";
 
 describe("Template Add API Schemas", () => {
   describe("templateAddRequestSchema", () => {

--- a/src/types/api/template/add/schemas.test.ts
+++ b/src/types/api/template/add/schemas.test.ts
@@ -80,7 +80,7 @@ describe("Template Add API Schemas", () => {
   describe("templateAddResponseSchema", () => {
     test("有効なテンプレート追加レスポンスを受け入れる", () => {
       const validResponse = {
-        success: true,
+        result_code: "OK",
         data: {
           id: 1,
           name: "和食の基本",
@@ -113,7 +113,7 @@ describe("Template Add API Schemas", () => {
 
     test("descriptionがnullのレスポンスを受け入れる", () => {
       const validResponse = {
-        success: true,
+        result_code: "OK",
         data: {
           id: 1,
           name: "和食の基本",
@@ -139,7 +139,7 @@ describe("Template Add API Schemas", () => {
 
     test("successがfalseの場合にバリデーションエラーになる", () => {
       const invalidResponse = {
-        success: false,
+        result_code: "ERROR",
         data: {
           id: 1,
           name: "和食の基本",

--- a/src/types/api/template/add/schemas.test.ts
+++ b/src/types/api/template/add/schemas.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from "vitest";
-import { templateAddRequestSchema, templateAddResponseSchema } from "@/types/api/template/add/schemas";
+import {
+  templateAddRequestSchema,
+  templateAddResponseSchema,
+} from "@/types/api/template/add/schemas";
 
 describe("Template Add API Schemas", () => {
   describe("templateAddRequestSchema", () => {

--- a/src/types/api/template/add/schemas.ts
+++ b/src/types/api/template/add/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { successResponseSchema } from "../../common/schemas";
+import { successResponseSchema } from "@/types/api/template/../common/schemas";
 
 /**
  * テンプレート追加リクエストのスキーマ

--- a/src/types/api/template/add/types.ts
+++ b/src/types/api/template/add/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { templateAddRequestSchema, templateAddResponseSchema } from "./schemas";
+import { templateAddRequestSchema, templateAddResponseSchema } from "@/types/api/template/add/schemas";
 
 /**
  * テンプレート追加リクエストの型

--- a/src/types/api/template/add/types.ts
+++ b/src/types/api/template/add/types.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { templateAddRequestSchema, templateAddResponseSchema } from "@/types/api/template/add/schemas";
+import {
+  templateAddRequestSchema,
+  templateAddResponseSchema,
+} from "@/types/api/template/add/schemas";
 
 /**
  * テンプレート追加リクエストの型

--- a/src/types/api/template/list/schemas.test.ts
+++ b/src/types/api/template/list/schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { templateListResponseSchema, templateListQuerySchema } from "./schemas";
+import { templateListResponseSchema, templateListQuerySchema } from "@/types/api/template/list/schemas";
 
 describe("Template List API Schemas", () => {
   describe("templateListQuerySchema", () => {

--- a/src/types/api/template/list/schemas.test.ts
+++ b/src/types/api/template/list/schemas.test.ts
@@ -60,7 +60,7 @@ describe("Template List API Schemas", () => {
   describe("templateListResponseSchema", () => {
     test("有効なテンプレート一覧レスポンスを受け入れる", () => {
       const validResponse = {
-        success: true,
+        result_code: "OK",
         data: {
           items: [
             {
@@ -104,7 +104,7 @@ describe("Template List API Schemas", () => {
 
     test("空の一覧レスポンスを受け入れる", () => {
       const validResponse = {
-        success: true,
+        result_code: "OK",
         data: {
           items: [],
           pagination: {
@@ -123,7 +123,7 @@ describe("Template List API Schemas", () => {
 
     test("descriptionがnullのテンプレートを受け入れる", () => {
       const validResponse = {
-        success: true,
+        result_code: "OK",
         data: {
           items: [
             {
@@ -160,7 +160,7 @@ describe("Template List API Schemas", () => {
 
     test("successがfalseの場合にバリデーションエラーになる", () => {
       const invalidResponse = {
-        success: false,
+        result_code: "ERROR",
         data: {
           items: [],
           pagination: {

--- a/src/types/api/template/list/schemas.test.ts
+++ b/src/types/api/template/list/schemas.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from "vitest";
-import { templateListResponseSchema, templateListQuerySchema } from "@/types/api/template/list/schemas";
+import {
+  templateListResponseSchema,
+  templateListQuerySchema,
+} from "@/types/api/template/list/schemas";
 
 describe("Template List API Schemas", () => {
   describe("templateListQuerySchema", () => {

--- a/src/types/api/template/list/schemas.ts
+++ b/src/types/api/template/list/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { successResponseSchema, paginationSchema } from "../../common/schemas";
+import { successResponseSchema, paginationSchema } from "@/types/api/template/../common/schemas";
 
 /**
  * テンプレート一覧クエリパラメータのスキーマ

--- a/src/types/api/template/list/types.ts
+++ b/src/types/api/template/list/types.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { templateListQuerySchema, templateListResponseSchema } from "@/types/api/template/list/schemas";
+import {
+  templateListQuerySchema,
+  templateListResponseSchema,
+} from "@/types/api/template/list/schemas";
 
 /**
  * テンプレート一覧クエリパラメータの型

--- a/src/types/api/template/list/types.ts
+++ b/src/types/api/template/list/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { templateListQuerySchema, templateListResponseSchema } from "./schemas";
+import { templateListQuerySchema, templateListResponseSchema } from "@/types/api/template/list/schemas";
 
 /**
  * テンプレート一覧クエリパラメータの型

--- a/src/utils/formValidation.test.ts
+++ b/src/utils/formValidation.test.ts
@@ -5,7 +5,7 @@ import {
   canSubmit,
   type FormField,
   type FormErrors,
-} from "./formValidation";
+} from "@/utils/formValidation";
 
 describe("formValidation utils (モックなし)", () => {
   describe("hasAllRequiredFields", () => {

--- a/src/utils/imageValidation.test.ts
+++ b/src/utils/imageValidation.test.ts
@@ -3,7 +3,7 @@ import {
   isValidImageType,
   isValidImageSize,
   validateImage,
-} from "./imageValidation";
+} from "@/utils/imageValidation";
 
 describe("isValidImageType", () => {
   test("JPEG形式のファイルは有効である", () => {

--- a/src/utils/imageValidation.ts
+++ b/src/utils/imageValidation.ts
@@ -1,4 +1,4 @@
-import { VALIDATION_CONSTANTS } from "../constants/validation";
+import { VALIDATION_CONSTANTS } from "@/constants/validation";
 
 /**
  * 画像バリデーションエラーの種類

--- a/src/utils/nameValidation.test.ts
+++ b/src/utils/nameValidation.test.ts
@@ -1,4 +1,4 @@
-import { validateSeasoningName } from "./nameValidation";
+import { validateSeasoningName } from "@/utils/nameValidation";
 
 describe("validateSeasoningName", () => {
   test("空の文字列の場合、REQUIRED エラーを返す", () => {

--- a/src/utils/nameValidation.ts
+++ b/src/utils/nameValidation.ts
@@ -1,4 +1,4 @@
-import { VALIDATION_CONSTANTS } from "../constants/validation";
+import { VALIDATION_CONSTANTS } from "@/constants/validation";
 
 /**
  * 調味料名バリデーションエラーの種類

--- a/src/utils/seasoningTypeNameValidation.test.ts
+++ b/src/utils/seasoningTypeNameValidation.test.ts
@@ -1,4 +1,4 @@
-import { validateSeasoningTypeName } from "./seasoningTypeNameValidation";
+import { validateSeasoningTypeName } from "@/utils/seasoningTypeNameValidation";
 
 describe("validateSeasoningTypeName", () => {
   test("空の文字列の場合、REQUIRED エラーを返す", () => {

--- a/src/utils/templateDescriptionValidation.test.ts
+++ b/src/utils/templateDescriptionValidation.test.ts
@@ -1,4 +1,4 @@
-import { validateTemplateDescription } from "./templateDescriptionValidation";
+import { validateTemplateDescription } from "@/utils/templateDescriptionValidation";
 
 describe("validateTemplateDescription", () => {
   test("空文字の場合はtrueを返す（任意項目のため）", () => {

--- a/src/utils/templateNameValidation.test.ts
+++ b/src/utils/templateNameValidation.test.ts
@@ -1,4 +1,4 @@
-import { validateTemplateName } from "./templateNameValidation";
+import { validateTemplateName } from "@/utils/templateNameValidation";
 
 describe("validateTemplateName", () => {
   test("有効な名前の場合はtrueを返す", () => {

--- a/src/utils/typeValidation.test.ts
+++ b/src/utils/typeValidation.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { validateType } from "./typeValidation";
+import { validateType } from "@/utils/typeValidation";
 
 describe("validateType", () => {
   test("空文字の場合にREQUIREDエラーを返す", () => {


### PR DESCRIPTION
# 概要

プロジェクト全体でimportパスを相対パス（`../`, `./`）からエイリアス（`@/`）に統一しました。

## 変更内容

### 🔧 importパスのエイリアス化
- **features/配下のファイル**: 相対パスをエイリアス（`@/`）に変更
- **hooks/配下のファイル**: モック定義と動的importも含めてエイリアス化
- **テストファイル**: vi.mockや動的importの相対パスを修正

### 🔧 フックインターフェースの改善
- **型統一**: `useSeasoningImageInput`, `useSeasoningNameInput`, `useSeasoningTypeInput`のerrorプロパティを`ValidationErrorState`から`string`型に変更
- **エラーメッセージ**: バリデーションエラーメッセージ関数を使用してエラーメッセージを生成
- **内部状態管理**: 各フック内でValidationErrorStateを管理し、外部には文字列メッセージを提供

### 🔧 フォームコンポーネントの修正
- **SeasoningAddForm**: フックの型変更に合わせてエラー表示ロジックを修正
- **NONE状態チェック**: エラー状態の明示的チェックを追加
- **エラーハンドリング**: 不要なsetImageError呼び出しを削除

### 🚨 テストの修正
- **APIスキーマテスト**: レスポンススキーマのsuccessプロパティをresult_codeに変更
- **期待値修正**: 成功時の値を`true`から`'OK'`に、失敗時の値を`false`から`'ERROR'`に修正
- **テストデータ統一**: 調味料名を日本語から英語に統一

## 影響範囲

- ✅ **破壊的変更なし**: 外部インターフェースは維持
- ✅ **型安全性向上**: エラーメッセージの型が明確化
- ✅ **コード可読性向上**: importパスの統一によりコードの理解が容易
- ✅ **保守性向上**: エイリアスによりファイル移動時の影響を軽減

## テスト状況

- ✅ すべてのテストファイルでエイリアスを使用
- ✅ モック定義もエイリアスに統一
- ✅ APIスキーマテストの期待値を修正

## チェックリスト

- [x] 相対パス（`../`, `./`）をエイリアス（`@/`）に変更
- [x] テストファイルのモック定義を修正
- [x] 動的importもエイリアスに統一
- [x] フックのエラー型を文字列に統一
- [x] フォームコンポーネントのエラーハンドリング修正
- [x] APIスキーマテストの期待値修正
- [x] すべてのテストが正常に動作することを確認