### PR TITLE
♻️ [Refactoring]: 数値定数から不要なas constを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "check": "tsc --noEmit"
   },
   "dependencies": {
     "mysql2": "^3.14.1",

--- a/src/constants/database/connectionLimits.ts
+++ b/src/constants/database/connectionLimits.ts
@@ -21,19 +21,19 @@ export type ConnectionLimits = {
  * 本番環境のデータベース接続プール数
  * 高トラフィックに対応するため多めの接続数を設定
  */
-export const PRODUCTION_CONNECTION_LIMIT = 10 as const;
+export const PRODUCTION_CONNECTION_LIMIT = 10;
 
 /**
  * 開発環境のデータベース接続プール数
  * 開発作業に必要十分な接続数を設定
  */
-export const DEVELOPMENT_CONNECTION_LIMIT = 5 as const;
+export const DEVELOPMENT_CONNECTION_LIMIT = 5;
 
 /**
  * テスト環境のデータベース接続プール数
  * テスト実行時のリソース消費を最小化するため少なめの接続数を設定
  */
-export const TEST_CONNECTION_LIMIT = 3 as const;
+export const TEST_CONNECTION_LIMIT = 3;
 
 /**
  * 環境別データベース接続制限設定

--- a/src/constants/database/timeouts.ts
+++ b/src/constants/database/timeouts.ts
@@ -30,25 +30,25 @@ export type DatabaseTimeouts = {
  * 本番環境のデータベース取得タイムアウト（ミリ秒）
  * 接続プールから接続を取得する際の最大待機時間
  */
-export const PRODUCTION_ACQUIRE_TIMEOUT = 60000 as const;
+export const PRODUCTION_ACQUIRE_TIMEOUT = 60000;
 
 /**
  * 本番環境のデータベースクエリタイムアウト（ミリ秒）
  * SQLクエリ実行の最大待機時間
  */
-export const PRODUCTION_QUERY_TIMEOUT = 60000 as const;
+export const PRODUCTION_QUERY_TIMEOUT = 60000;
 
 /**
  * 開発環境のデータベース取得タイムアウト（ミリ秒）
  * 開発時の応答性を重視した短めの設定
  */
-export const DEVELOPMENT_ACQUIRE_TIMEOUT = 30000 as const;
+export const DEVELOPMENT_ACQUIRE_TIMEOUT = 30000;
 
 /**
  * 開発環境のデータベースクエリタイムアウト（ミリ秒）
  * 開発時の応答性を重視した短めの設定
  */
-export const DEVELOPMENT_QUERY_TIMEOUT = 30000 as const;
+export const DEVELOPMENT_QUERY_TIMEOUT = 30000;
 
 /**
  * テスト環境のデータベース取得タイムアウト（ミリ秒）

--- a/src/constants/pagination.ts
+++ b/src/constants/pagination.ts
@@ -9,49 +9,49 @@
  * デフォルトのページサイズ
  * 一般的なリスト表示で使用される標準的なページサイズ
  */
-export const DEFAULT_PAGE_SIZE = 10 as const;
+export const DEFAULT_PAGE_SIZE = 10;
 
 /**
  * デフォルトのページ番号
  * ページネーション開始時の初期ページ
  */
-export const DEFAULT_PAGE_NUMBER = 1 as const;
+export const DEFAULT_PAGE_NUMBER = 1;
 
 /**
  * 最小ページ番号
  * ページネーションで指定可能な最小値
  */
-export const MIN_PAGE_NUMBER = 1 as const;
+export const MIN_PAGE_NUMBER = 1;
 
 /**
  * 最小ページサイズ
  * 1ページあたりの最小表示件数
  */
-export const MIN_PAGE_SIZE = 1 as const;
+export const MIN_PAGE_SIZE = 1;
 
 /**
  * 最大ページサイズ
  * パフォーマンスを考慮した1ページあたりの最大表示件数
  */
-export const MAX_PAGE_SIZE = 100 as const;
+export const MAX_PAGE_SIZE = 100;
 
 /**
  * 調味料一覧のページサイズ
  * 調味料リストで使用される専用のページサイズ
  */
-export const SEASONING_PAGE_SIZE = 10 as const;
+export const SEASONING_PAGE_SIZE = 10;
 
 /**
  * 調味料画像一覧のページサイズ
  * 調味料画像リストで使用される専用のページサイズ
  */
-export const SEASONING_IMAGE_PAGE_SIZE = 20 as const;
+export const SEASONING_IMAGE_PAGE_SIZE = 20;
 
 /**
  * 調味料種類一覧のページサイズ
  * 調味料種類リストで使用される専用のページサイズ
  */
-export const SEASONING_TYPE_PAGE_SIZE = 50 as const;
+export const SEASONING_TYPE_PAGE_SIZE = 50;
 
 /**
  * ページ番号とページサイズからオフセット値を計算する

--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -10,37 +10,37 @@
  * Storybookでの短いディレイ時間（500ms）
  * 軽微な操作やレスポンスの表現に使用
  */
-export const STORYBOOK_DELAY_SHORT = 500 as const;
+export const STORYBOOK_DELAY_SHORT = 500;
 
 /**
  * Storybookでの標準的なディレイ時間（1000ms）
  * 一般的な非同期処理のシミュレーションに使用
  */
-export const STORYBOOK_DELAY_MEDIUM = 1000 as const;
+export const STORYBOOK_DELAY_MEDIUM = 1000;
 
 /**
  * Storybookでの長めのディレイ時間（1500ms）
  * やや重い処理のシミュレーションに使用
  */
-export const STORYBOOK_DELAY_LONG = 1500 as const;
+export const STORYBOOK_DELAY_LONG = 1500;
 
 /**
  * Storybookでの非常に長いディレイ時間（2000ms）
  * 重い処理のシミュレーションに使用
  */
-export const STORYBOOK_DELAY_VERY_LONG = 2000 as const;
+export const STORYBOOK_DELAY_VERY_LONG = 2000;
 
 /**
  * Storybookでの極めて長いディレイ時間（5000ms）
  * 非常に重い処理やタイムアウトのシミュレーションに使用
  */
-export const STORYBOOK_DELAY_EXTRA_LONG = 5000 as const;
+export const STORYBOOK_DELAY_EXTRA_LONG = 5000;
 
 /**
  * テスト用の非同期処理ディレイ（0ms）
  * Promiseの解決を待つためのディレイ、実際の待機は不要
  */
-export const TEST_ASYNC_DELAY = 0 as const;
+export const TEST_ASYNC_DELAY = 0;
 
 /**
  * ディレイ時間の型定義


### PR DESCRIPTION
## 概要
TypeScriptにおいて数値定数に不要な `as const` が使用されていたため、これを削除してコードの品質を向上させました。

## 変更内容

### 修正対象ファイル
- `src/constants/ui.ts` - UI関連の定数（6箇所）
- `src/constants/pagination.ts` - ページネーション関連の定数（8箇所）
- `src/constants/database/connectionLimits.ts` - データベース接続制限定数（3箇所）
- `src/constants/database/timeouts.ts` - データベースタイムアウト定数（4箇所）
- `package.json` - TypeScript型チェック用スクリプト追加

### 修正内容
**Before:**
```typescript
export const STORYBOOK_DELAY_SHORT = 500 as const;
export const DEFAULT_PAGE_SIZE = 10 as const;
```

**After:**
```typescript
export const STORYBOOK_DELAY_SHORT = 500;
export const DEFAULT_PAGE_SIZE = 10;
```

### 技術的根拠
- **数値リテラル**には `as const` は不要（TypeScriptが自動的に適切な型を推論）
- **配列やオブジェクト**では引き続き `as const` を適切に使用
- コードの簡潔性と可読性が向上

### 追加機能
- `npm run check` コマンドを追加（TypeScript型チェック専用）

## テスト
- ✅ 既存のテストは全て通過（2件の既存テストエラーは今回の変更と無関係）
- ✅ TypeScriptコンパイルチェック実行済み
- ✅ 型推論が正常に動作することを確認

## レビューポイント
- 数値定数から `as const` が適切に削除されているか
- 配列やオブジェクトの `as const` は保持されているか
- 型の推論が正しく動作するか