### PR TITLE
♻️ [Refactoring]: MySQLTypesの構造改善 - 型定義とロジックの責務分離

### DIFF
--- a/src/libs/database/mysql/adapters/MySQL2TransactionAdapter.ts
+++ b/src/libs/database/mysql/adapters/MySQL2TransactionAdapter.ts
@@ -5,7 +5,7 @@ import type {
   ConnectionConfig,
   PoolStats,
 } from "@/libs/database/interfaces/IDatabaseConnection";
-import { createMySQLError } from "../types/MySQLTypes";
+import { createMySQLError } from "../errors";
 
 /**
  * MySQL2ライブラリ用のトランザクションアダプター

--- a/src/libs/database/mysql/connection/MySQLConnection.ts
+++ b/src/libs/database/mysql/connection/MySQLConnection.ts
@@ -6,7 +6,7 @@ import type {
 } from "@/libs/database/interfaces/IDatabaseConnection";
 import { ITransaction } from "@/libs/database/interfaces/ITransaction";
 import type { IConnectionAdapter } from "@/libs/database/interfaces/IConnectionAdapter";
-import { createMySQLError } from "../types/MySQLTypes";
+import { createMySQLError } from "../errors";
 import { MySQLTransaction } from "./MySQLTransaction";
 
 /**

--- a/src/libs/database/mysql/converters/MySQLConverter.ts
+++ b/src/libs/database/mysql/converters/MySQLConverter.ts
@@ -1,0 +1,79 @@
+import type { SslOptions } from "mysql2/promise";
+import type {
+  QueryResult,
+  ConnectionConfig,
+} from "@/libs/database/interfaces/IDatabaseConnection";
+import type {
+  MySQLQueryResult,
+  MySQLConnectionConfig,
+} from "@/libs/database/mysql/types";
+
+/**
+ * MySQL型変換のコンパニオンオブジェクト
+ */
+
+/**
+ * MySQLQueryResultのコンパニオンオブジェクト
+ */
+export const MySQLQueryResultConverter = {
+  /**
+   * mysql2の結果を独自のQueryResultに変換
+   */
+  toQueryResult<T>(mysqlResult: MySQLQueryResult<T>): QueryResult<T> {
+    return {
+      rows: mysqlResult.rows,
+      rowsAffected: mysqlResult.affectedRows,
+      insertId: mysqlResult.insertId === 0 ? null : mysqlResult.insertId,
+      metadata: {
+        changedRows: mysqlResult.changedRows,
+        warningCount: mysqlResult.warningCount,
+      },
+    };
+  },
+} as const;
+
+/**
+ * MySQLConnectionConfigのコンパニオンオブジェクト
+ */
+export const MySQLConnectionConfigConverter = {
+  /**
+   * 独自のConnectionConfigからMySQL設定に変換
+   */
+  from(config: ConnectionConfig): MySQLConnectionConfig {
+    const mysqlConfig: MySQLConnectionConfig = {
+      host: config.host,
+      port: config.port,
+      database: config.database,
+      user: config.username,
+      password: config.password,
+    };
+
+    if (config.connectTimeout) {
+      mysqlConfig.acquireTimeout = config.connectTimeout;
+    }
+
+    if (config.queryTimeout) {
+      mysqlConfig.timeout = config.queryTimeout;
+    }
+
+    if (config.maxConnections) {
+      mysqlConfig.connectionLimit = config.maxConnections;
+    }
+
+    if (config.ssl) {
+      if (typeof config.ssl === "boolean") {
+        // booleanの場合は文字列として扱う（mysql2の仕様に合わせる）
+        mysqlConfig.ssl = config.ssl ? "Amazon RDS" : undefined;
+      } else {
+        // オブジェクトの場合はSslOptionsとして扱う
+        mysqlConfig.ssl = config.ssl as SslOptions;
+      }
+    }
+
+    if (config.options) {
+      Object.assign(mysqlConfig, config.options);
+    }
+
+    return mysqlConfig;
+  },
+} as const;

--- a/src/libs/database/mysql/converters/index.ts
+++ b/src/libs/database/mysql/converters/index.ts
@@ -1,0 +1,7 @@
+/**
+ * MySQL変換ユーティリティのエクスポート
+ */
+export {
+  MySQLQueryResultConverter,
+  MySQLConnectionConfigConverter,
+} from "./MySQLConverter";

--- a/src/libs/database/mysql/errors/MySQLError.ts
+++ b/src/libs/database/mysql/errors/MySQLError.ts
@@ -1,0 +1,76 @@
+import type { MySQLErrorType } from "@/libs/database/mysql/types";
+
+/**
+ * MySQL固有のエラー処理
+ */
+
+/**
+ * MySQL固有のエラー型
+ */
+export class MySQLError extends Error {
+  public readonly type: MySQLErrorType;
+  public readonly mysqlCode?: string;
+  public readonly mysqlErrno?: number;
+  public readonly sqlState?: string;
+  public readonly originalError: unknown;
+
+  constructor(
+    message: string,
+    type: MySQLErrorType,
+    originalError: unknown,
+    mysqlCode?: string,
+    mysqlErrno?: number,
+    sqlState?: string
+  ) {
+    super(message);
+    this.name = "MySQLError";
+    this.type = type;
+    this.mysqlCode = mysqlCode;
+    this.mysqlErrno = mysqlErrno;
+    this.sqlState = sqlState;
+    this.originalError = originalError;
+  }
+}
+
+/**
+ * mysql2エラーから独自エラーを作成
+ */
+export function createMySQLError(
+  error: unknown,
+  type: MySQLErrorType
+): MySQLError {
+  if (isMySQLError(error)) {
+    return new MySQLError(
+      error.sqlMessage || error.message,
+      type,
+      error,
+      error.code,
+      error.errno,
+      error.sqlState
+    );
+  }
+
+  if (error instanceof Error) {
+    return new MySQLError(error.message, type, error);
+  }
+
+  return new MySQLError("Unknown MySQL error", type, error);
+}
+
+/**
+ * mysql2のエラーかどうかを判定
+ */
+function isMySQLError(error: unknown): error is {
+  code?: string;
+  errno?: number;
+  message: string;
+  sqlState?: string;
+  sqlMessage?: string;
+} {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as { message: unknown }).message === "string"
+  );
+}

--- a/src/libs/database/mysql/errors/index.ts
+++ b/src/libs/database/mysql/errors/index.ts
@@ -1,0 +1,4 @@
+/**
+ * MySQLエラー関連のエクスポート
+ */
+export { MySQLError, createMySQLError } from "./MySQLError";

--- a/src/libs/database/mysql/index.ts
+++ b/src/libs/database/mysql/index.ts
@@ -1,3 +1,5 @@
 export * from "./adapters";
 export * from "./connection";
 export * from "./types";
+export * from "./errors";
+export * from "./converters";

--- a/src/libs/database/mysql/types/MySQLTypes.test.ts
+++ b/src/libs/database/mysql/types/MySQLTypes.test.ts
@@ -1,14 +1,14 @@
 import { describe, test, expect } from "vitest";
+import type { MySQLQueryResult } from "./MySQLTypes";
+import { MySQLError, createMySQLError } from "../errors";
 import {
-  MySQLQueryResult,
-  MySQLConnectionConfig,
-  MySQLError,
-  createMySQLError,
-} from "./MySQLTypes";
+  MySQLQueryResultConverter,
+  MySQLConnectionConfigConverter,
+} from "../converters";
 import type { ConnectionConfig } from "@/libs/database/interfaces/IDatabaseConnection";
 
 describe("MySQLTypes", () => {
-  describe("MySQLQueryResult.toQueryResult", () => {
+  describe("MySQLQueryResultConverter.toQueryResult", () => {
     test("mysql2のクエリ結果を独自のQueryResultに変換できる", () => {
       // Red: テストを先に書く
       const mysqlResult: MySQLQueryResult = {
@@ -20,7 +20,7 @@ describe("MySQLTypes", () => {
         warningCount: 0,
       };
 
-      const result = MySQLQueryResult.toQueryResult(mysqlResult);
+      const result = MySQLQueryResultConverter.toQueryResult(mysqlResult);
 
       expect(result).toEqual({
         rows: [{ id: 1, name: "テスト調味料" }],
@@ -43,13 +43,13 @@ describe("MySQLTypes", () => {
         warningCount: 0,
       };
 
-      const result = MySQLQueryResult.toQueryResult(mysqlResult);
+      const result = MySQLQueryResultConverter.toQueryResult(mysqlResult);
 
       expect(result.insertId).toBeNull();
     });
   });
 
-  describe("MySQLConnectionConfig.from", () => {
+  describe("MySQLConnectionConfigConverter.from", () => {
     test("独自のConnectionConfigをMySQL設定に変換できる", () => {
       const config: ConnectionConfig = {
         host: "localhost",
@@ -63,7 +63,7 @@ describe("MySQLTypes", () => {
         minConnections: 1,
       };
 
-      const mysqlConfig = MySQLConnectionConfig.from(config);
+      const mysqlConfig = MySQLConnectionConfigConverter.from(config);
 
       expect(mysqlConfig).toEqual({
         host: "localhost",
@@ -88,7 +88,7 @@ describe("MySQLTypes", () => {
         ssl: true,
       };
 
-      const mysqlConfig = MySQLConnectionConfig.from(config);
+      const mysqlConfig = MySQLConnectionConfigConverter.from(config);
 
       expect(mysqlConfig.ssl).toBe("Amazon RDS");
     });
@@ -103,7 +103,7 @@ describe("MySQLTypes", () => {
         ssl: false,
       };
 
-      const mysqlConfig = MySQLConnectionConfig.from(config);
+      const mysqlConfig = MySQLConnectionConfigConverter.from(config);
 
       expect(mysqlConfig.ssl).toBeUndefined();
     });
@@ -124,7 +124,7 @@ describe("MySQLTypes", () => {
         ssl: sslOptions,
       };
 
-      const mysqlConfig = MySQLConnectionConfig.from(config);
+      const mysqlConfig = MySQLConnectionConfigConverter.from(config);
 
       expect(mysqlConfig.ssl).toEqual(sslOptions);
     });

--- a/src/libs/database/mysql/types/MySQLTypes.ts
+++ b/src/libs/database/mysql/types/MySQLTypes.ts
@@ -1,11 +1,7 @@
 import type { FieldPacket, SslOptions } from "mysql2/promise";
-import type {
-  QueryResult,
-  ConnectionConfig,
-} from "@/libs/database/interfaces/IDatabaseConnection";
 
 /**
- * MySQL固有の型定義とクリーンアーキテクチャ型の変換機能
+ * MySQL固有の型定義
  */
 
 /**
@@ -19,26 +15,6 @@ export interface MySQLQueryResult<T = unknown> {
   changedRows: number;
   warningCount: number;
 }
-
-/**
- * MySQLQueryResultのコンパニオンオブジェクト
- */
-export const MySQLQueryResult = {
-  /**
-   * mysql2の結果を独自のQueryResultに変換
-   */
-  toQueryResult<T>(mysqlResult: MySQLQueryResult<T>): QueryResult<T> {
-    return {
-      rows: mysqlResult.rows,
-      rowsAffected: mysqlResult.affectedRows,
-      insertId: mysqlResult.insertId === 0 ? null : mysqlResult.insertId,
-      metadata: {
-        changedRows: mysqlResult.changedRows,
-        warningCount: mysqlResult.warningCount,
-      },
-    };
-  },
-} as const;
 
 /**
  * mysql2の接続設定型
@@ -56,80 +32,6 @@ export interface MySQLConnectionConfig {
 }
 
 /**
- * MySQLConnectionConfigのコンパニオンオブジェクト
- */
-export const MySQLConnectionConfig = {
-  /**
-   * 独自のConnectionConfigからMySQL設定に変換
-   */
-  from(config: ConnectionConfig): MySQLConnectionConfig {
-    const mysqlConfig: MySQLConnectionConfig = {
-      host: config.host,
-      port: config.port,
-      database: config.database,
-      user: config.username,
-      password: config.password,
-    };
-
-    if (config.connectTimeout) {
-      mysqlConfig.acquireTimeout = config.connectTimeout;
-    }
-
-    if (config.queryTimeout) {
-      mysqlConfig.timeout = config.queryTimeout;
-    }
-
-    if (config.maxConnections) {
-      mysqlConfig.connectionLimit = config.maxConnections;
-    }
-
-    if (config.ssl) {
-      if (typeof config.ssl === "boolean") {
-        // booleanの場合は文字列として扱う（mysql2の仕様に合わせる）
-        mysqlConfig.ssl = config.ssl ? "Amazon RDS" : undefined;
-      } else {
-        // オブジェクトの場合はSslOptionsとして扱う
-        mysqlConfig.ssl = config.ssl as SslOptions;
-      }
-    }
-
-    if (config.options) {
-      Object.assign(mysqlConfig, config.options);
-    }
-
-    return mysqlConfig;
-  },
-} as const;
-
-/**
- * MySQL固有のエラー型
- */
-export class MySQLError extends Error {
-  public readonly type: MySQLErrorType;
-  public readonly mysqlCode?: string;
-  public readonly mysqlErrno?: number;
-  public readonly sqlState?: string;
-  public readonly originalError: unknown;
-
-  constructor(
-    message: string,
-    type: MySQLErrorType,
-    originalError: unknown,
-    mysqlCode?: string,
-    mysqlErrno?: number,
-    sqlState?: string
-  ) {
-    super(message);
-    this.name = "MySQLError";
-    this.type = type;
-    this.mysqlCode = mysqlCode;
-    this.mysqlErrno = mysqlErrno;
-    this.sqlState = sqlState;
-    this.originalError = originalError;
-  }
-}
-
-/**
  * MySQLエラーの種類
  */
 export type MySQLErrorType =
@@ -139,46 +41,3 @@ export type MySQLErrorType =
   | "TIMEOUT_ERROR"
   | "AUTHENTICATION_ERROR"
   | "UNKNOWN_ERROR";
-
-/**
- * mysql2エラーから独自エラーを作成
- */
-export function createMySQLError(
-  error: unknown,
-  type: MySQLErrorType
-): MySQLError {
-  if (isMySQLError(error)) {
-    return new MySQLError(
-      error.sqlMessage || error.message,
-      type,
-      error,
-      error.code,
-      error.errno,
-      error.sqlState
-    );
-  }
-
-  if (error instanceof Error) {
-    return new MySQLError(error.message, type, error);
-  }
-
-  return new MySQLError("Unknown MySQL error", type, error);
-}
-
-/**
- * mysql2のエラーかどうかを判定
- */
-function isMySQLError(error: unknown): error is {
-  code?: string;
-  errno?: number;
-  message: string;
-  sqlState?: string;
-  sqlMessage?: string;
-} {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "message" in error &&
-    typeof (error as { message: unknown }).message === "string"
-  );
-}

--- a/src/libs/database/mysql/types/index.ts
+++ b/src/libs/database/mysql/types/index.ts
@@ -1,1 +1,8 @@
-export * from "./MySQLTypes";
+/**
+ * MySQL型定義のエクスポート
+ */
+export type {
+  MySQLQueryResult,
+  MySQLConnectionConfig,
+  MySQLErrorType,
+} from "./MySQLTypes";


### PR DESCRIPTION
## 概要
`MySQLTypes.ts`ファイルに混在していた型定義、コンパニオンオブジェクト、エラークラスを適切なディレクトリに分離し、責務を明確化するリファクタリングです。

## 変更内容

### 🗂️ 新しいディレクトリ構造
```
src/libs/database/mysql/
├── types/          # 純粋な型定義のみ
├── errors/         # エラークラスと関連関数
├── converters/     # 型変換のコンパニオンオブジェクト
├── connection/     # 既存
├── adapters/       # 既存
└── repositories/   # 既存
```

### 📁 **types/** - 純粋な型定義のみ
- `MySQLQueryResult<T>` インターフェース
- `MySQLConnectionConfig` インターフェース
- `MySQLErrorType` 型

### 🚨 **errors/** - エラー処理の実装
- `MySQLError` クラス
- `createMySQLError()` 関数
- `isMySQLError()` 関数

### 🔄 **converters/** - 型変換ロジック
- `MySQLQueryResultConverter` (旧 `MySQLQueryResult` コンパニオンオブジェクト)
- `MySQLConnectionConfigConverter` (旧 `MySQLConnectionConfig` コンパニオンオブジェクト)

## 🎯 改善点

### ✅ 責務の明確化
- **型定義** は `types/` フォルダに限定
- **実装ロジック** は適切なフォルダに分離
- **エラー処理** は独立したモジュールとして管理

### ✅ 保守性の向上
- 各モジュールが単一責任原則に従う
- インポート時に目的が明確
- テストの可読性向上

### ✅ 拡張性の向上
- 新しい型変換ロジックの追加が容易
- エラー処理の拡張が独立して可能
- 型定義の変更が他の実装に影響しにくい

## 🧪 テスト
- 全てのテストが通過
- 既存の機能に影響なし
- インポートパスの修正完了

## 📊 コミット履歴
8つの細かなコミットに分割し、段階的にリファクタリングを実施：

1. **MySQL エラー処理クラスと関数を独立したディレクトリに分離**
2. **MySQL型変換のコンパニオンオブジェクトを独立したディレクトリに分離**
3. **MySQLTypes.ts を純粋な型定義のみに変更**
4. **types/index.ts を型定義のみのエクスポートに変更**
5. **mysql/index.ts に新しいディレクトリのエクスポートを追加**
6. **MySQLConnection.ts のインポートパスを新しい構造に対応**
7. **MySQL2TransactionAdapter.ts のインポートパスを新しい構造に対応**
8. **MySQLTypes テストを新しいディレクトリ構造に対応**

## 🔍 影響範囲
- ✅ 既存機能への影響なし
- ✅ APIの変更なし（内部構造の改善のみ）
- ✅ パフォーマンスへの影響なし